### PR TITLE
Adding IsBuyBoxWinner field into OfferElement

### DIFF
--- a/Source/FikaAmazonAPI/NotificationMessages/OfferElement.cs
+++ b/Source/FikaAmazonAPI/NotificationMessages/OfferElement.cs
@@ -30,6 +30,12 @@ namespace FikaAmazonAPI.NotificationMessages
         public bool IsFulfilledByAmazon { get; set; }
 
         /// <summary>
+        /// Indicates if the offer is buy box winner
+        /// </summary>
+        [JsonProperty("IsBuyBoxWinner")]
+        public bool IsBuyBoxWinner { get; set; }
+
+        /// <summary>
         /// An explanation about the purpose of this instance.
         /// </summary>
         [JsonProperty("ListingPrice")]


### PR DESCRIPTION
Hey, I've noticed FikaAmazonAPI.NotificationMessages.OfferElement is missing IsBuyBoxWinner.
It is currently supplied in AnyOfferChanged messages, payload v 1.0 
Please consider accepting this pull request