### PR TITLE
Implement sandbox test cases concept and allow to return test_case_20…

### DIFF
--- a/Source/FikaAmazonAPI/FikaAmazonAPI.csproj
+++ b/Source/FikaAmazonAPI/FikaAmazonAPI.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
   </ItemGroup>

--- a/Source/FikaAmazonAPI/Parameter/IHasParameterizedTestCase.cs
+++ b/Source/FikaAmazonAPI/Parameter/IHasParameterizedTestCase.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FikaAmazonAPI.Parameter
+{
+    public interface IHasParameterizedTestCase
+    {
+        string TestCase { get; set; }
+        Dictionary<string, List<KeyValuePair<string, string>>> SandboxQueryParameters { get; }
+    }
+}

--- a/Source/FikaAmazonAPI/Parameter/Order/ParameterOrderList.cs
+++ b/Source/FikaAmazonAPI/Parameter/Order/ParameterOrderList.cs
@@ -9,8 +9,13 @@ using System.Text;
 
 namespace FikaAmazonAPI.Parameter.Order
 {
-    public class ParameterOrderList :  ParameterBased, IParameterBasedPII
+    public class ParameterOrderList :  ParameterBased, IParameterBasedPII, IHasParameterizedTestCase
     {
+        public ParameterOrderList()
+        {
+            SandboxQueryParameters = Sandbox.SandboxQueryParameters<ParameterOrderList>();
+        }
+
         /// <summary>
         /// A date used for selecting orders created after (or at) a specified time. Only orders placed after the specified time are returned. Either the CreatedAfter parameter or the LastUpdatedAfter parameter is required. Both cannot be empty. The date must be in ISO 8601 format.	
         /// </summary>
@@ -84,5 +89,8 @@ namespace FikaAmazonAPI.Parameter.Order
         public string StoreChainStoreId { get; set; }
         public bool IsNeedRestrictedDataToken { get; set; }
         public CreateRestrictedDataTokenRequest RestrictedDataTokenRequest { get; set; }
+        public string TestCase { get; set; }
+
+        public Dictionary<string, List<KeyValuePair<string, string>>> SandboxQueryParameters { get; }
     }
 }

--- a/Source/FikaAmazonAPI/Services/OrderService.cs
+++ b/Source/FikaAmazonAPI/Services/OrderService.cs
@@ -25,8 +25,7 @@ namespace FikaAmazonAPI.Services
         {
             var orderList = new OrderList();
 
-            var queryParameters = searchOrderList.getParameters();
-
+            var queryParameters = searchOrderList.getParameters(this.AmazonCredential.Environment == Constants.Environments.Sandbox);
 
             CreateAuthorizedRequest(OrdersApiUrls.Orders, RestSharp.Method.GET, queryParameters,parameter: searchOrderList);
             var response = ExecuteRequest<GetOrdersResponse>();

--- a/Source/FikaAmazonAPI/Utils/Constants.cs
+++ b/Source/FikaAmazonAPI/Utils/Constants.cs
@@ -11,6 +11,7 @@ namespace FikaAmazonAPI.Utils
     {
         public readonly static string AmazonToeknEndPoint = "https://api.amazon.com/auth/o2/token";
         public readonly static string DateISO8601Format = "yyyy-MM-ddTHH:mm:ss.fffZ";
+        public readonly static string TestCase200 = "TEST_CASE_200";
         
         [JsonConverter(typeof(StringEnumConverter))]
         public enum Environments

--- a/Source/FikaAmazonAPI/Utils/Sandbox.cs
+++ b/Source/FikaAmazonAPI/Utils/Sandbox.cs
@@ -1,0 +1,26 @@
+﻿using FikaAmazonAPI.Parameter;
+using FikaAmazonAPI.Parameter.Order;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FikaAmazonAPI.Utils
+{
+    internal static class Sandbox
+    {
+        public static Dictionary<string, List<KeyValuePair<string, string>>> SandboxQueryParameters<T>() where T : IHasParameterizedTestCase
+        {
+            var queryParameters = new Dictionary<string, List<KeyValuePair<string, string>>>();
+            if (typeof(T) == typeof(ParameterOrderList))
+            {
+                queryParameters.Add(Constants.TestCase200, new List<KeyValuePair<string, string>>()
+                {
+                    new KeyValuePair<string, string>("CreatedAfter", Constants.TestCase200),
+                    new KeyValuePair<string, string>("MarketplaceIds", "ATVPDKIKX0DER")
+                });
+            }
+
+            return queryParameters;
+        }
+    }
+}


### PR DESCRIPTION
Implement sandbox test cases concept and allow to return test_case_200 static data of GetOrders call.

Concept idea of how we can specify test cases of various calls which can accept sandbox static query parameters data.

How I use this concept in my code:
```
var orders = amazonConnection.Orders.GetOrders
                    (
                        new FikaAmazonAPI.Parameter.Order.ParameterOrderList()
                        {
                            TestCase = "TEST_CASE_200"
                        }
                    );
```