### PR TITLE
Adding NO_VOEC value to DeemedResellerCategoryEnum

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/OrderItem.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/OrderItem.cs
@@ -43,7 +43,13 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Orders
             /// Enum UOSS for value: UOSS
             /// </summary>
             [EnumMember(Value = "UOSS")]
-            UOSS = 2
+            UOSS = 2,
+
+            /// <summary>
+            /// Enum NO_VOEC for value: NO_VOEC
+            /// </summary>
+            [EnumMember(Value = "NO_VOEC")]
+            NO_VOEC = 3
         }
 
         /// <summary>


### PR DESCRIPTION
I hit an error with DeemedResellerCategoryEnum being set to NO_VOEC, which is not in the documentation, so I have added to allow it to deserialise correctly