### PR TITLE
change order of Item.AmazonOrderItemCode

### DIFF
--- a/Source/FikaAmazonAPI/ConstructFeed/Messages/OrderFulfillmentMessage.cs
+++ b/Source/FikaAmazonAPI/ConstructFeed/Messages/OrderFulfillmentMessage.cs
@@ -38,6 +38,8 @@ namespace FikaAmazonAPI.ConstructFeed.Messages
     [XmlRoot(ElementName = "Item")]
     public class Item
     {
+        [XmlElement(ElementName = "AmazonOrderItemCode")]
+        public string AmazonOrderItemCode { get; set; }
         [XmlElement(ElementName = "MerchantOrderItemID")]
         public string MerchantOrderItemID { get; set; }
         [XmlElement(ElementName = "MerchantFulfillmentItemID")]
@@ -46,8 +48,6 @@ namespace FikaAmazonAPI.ConstructFeed.Messages
         public int Quantity { get; set; }
         [XmlElement(ElementName = "TransparencyCode")]
         public List<string> TransparencyCode { get; set; }
-        [XmlElement(ElementName = "AmazonOrderItemCode")]
-        public string AmazonOrderItemCode { get; set; }
     }
 
     [XmlRoot(ElementName = "ShipFromAddress")]


### PR DESCRIPTION
changed order of Item.AmazonOrderItemCode element so it is at the beginning as dictated by 
https://images-na.ssl-images-amazon.com/images/G/01/rainier/help/xsd/release_4_1/OrderFulfillment.xsd

Otherwise API it gives error:
"We are unable to process the XML feed because one or more items are invalid"

ToXml() method when serializes to XML uses order of class members as in declaration