### PR TITLE
Added GB_VOEC Enum

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/OrderItem.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/OrderItem.cs
@@ -50,6 +50,12 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Orders
             /// </summary>
             [EnumMember(Value = "NO_VOEC")]
             NO_VOEC = 3
+            
+            /// <summary>
+            /// Enum GB_VOEC for value: GB_VOEC
+            /// </summary>
+            [EnumMember(Value = "GB_VOEC")]
+            GB_VOEC = 4
         }
 
         /// <summary>


### PR DESCRIPTION
This enum value is not present in the [docs](https://developer-docs.amazon.com/sp-api/docs/orders-api-v0-reference#deemedresellercategory) but I get the following error: 
```Error converting value "GB_VOEC" to type 'System.Nullable`1[FikaAmazonAPI.AmazonSpApiSDK.Models.Orders.OrderItem+DeemedResellerCategoryEnum]'. Path 'payload.OrderItems[0].DeemedResellerCategory', line 1, position 831.```