### PR TITLE
Added empty constructor to MoneyType

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ProductPricing/MoneyType.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ProductPricing/MoneyType.cs
@@ -24,6 +24,12 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.ProductPricing
     public partial class MoneyType : IEquatable<MoneyType>, IValidatableObject
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="OfferDetail" /> class.
+        /// </summary>
+        [JsonConstructorAttribute]
+        public MoneyType() { }
+    
+        /// <summary>
         /// Initializes a new instance of the <see cref="MoneyType" /> class.
         /// </summary>
         /// <param name="CurrencyCode">The currency code in ISO 4217 format..</param>


### PR DESCRIPTION
Without an empty constructor deserializing to MoneyType throws an error.