### PR TITLE
ShipmentStatusList is made of ShipmentStatus items

### DIFF
--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/ParameterGetShipments.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/ParameterGetShipments.cs
@@ -1,13 +1,14 @@
-﻿using FikaAmazonAPI.Search;
+using FikaAmazonAPI.Search;
 using System;
 using System.Collections.Generic;
 using static FikaAmazonAPI.Utils.Constants;
+using FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInbound;
 
 namespace FikaAmazonAPI.Parameter.FulFillmentInbound
 {
     public class ParameterGetShipments : ParameterBased
     {
-        public IList<ShipmentStatusList> ShipmentStatusList { get; set; }
+        public IList<ShipmentStatus> ShipmentStatusList { get; set; }
         public IList<string> ShipmentIdList { get; set; }
         public DateTime? LastUpdatedAfter { get; set; }
         public DateTime? LastUpdatedBefore { get; set; }


### PR DESCRIPTION
This is a critical fix, without this change you can not run getShipments like this.
var param = new Parameter.FulFillmentInbound.ParameterGetShipments()
            {
                QueryType = Constants.QueryType.DATE_RANGE,
                MarketplaceId = MarketPlace.US.ID,
                ShipmentStatusList = (new List<ShipmentStatus> { ShipmentStatus.CLOSED, ShipmentStatus.DELIVERED, ShipmentStatus.RECEIVING }),
                LastUpdatedAfter = DateTime.Now.AddDays(-60),
                LastUpdatedBefore = DateTime.Now
            };
            return amazonConnection.FulFillmentInbound.GetShipments(param);