### PR TITLE
Vendor orders

### DIFF
--- a/Source/FikaAmazonAPI/Parameter/VendorDirectFulfillmentOrders/ParameterVendorDirectFulfillmentGetOrders.cs
+++ b/Source/FikaAmazonAPI/Parameter/VendorDirectFulfillmentOrders/ParameterVendorDirectFulfillmentGetOrders.cs
@@ -10,8 +10,8 @@ namespace FikaAmazonAPI.Parameter.VendorDirectFulfillmentOrders
         public string ShipFromPartyId { get; set; }
         public OrderStatusEnum Status { get; set; }
         public long? Limit { get; set; }
-        public DateTime? CreatedAfter { get; set; }
-        public DateTime? CreatedBefore { get; set; }
+        public DateTime? createdAfter { get; set; }
+        public DateTime? createdBefore { get; set; }
         public SortOrderEnum SortOrder { get; set; }
         public string NextToken { get; set; }
         public bool? IncludeDetails { get; set; }

--- a/Source/FikaAmazonAPI/Services/VendorDirectFulfillmentOrderService.cs
+++ b/Source/FikaAmazonAPI/Services/VendorDirectFulfillmentOrderService.cs
@@ -21,7 +21,8 @@ namespace FikaAmazonAPI.Services
             var orderList = new List<Order>();
 
             var queryParameters = searchOrderList.getParameters();
-            await CreateAuthorizedRequestAsync(VendorDirectFulfillmentOrdersApiUrls.GetOrders, RestSharp.Method.GET, parameter: queryParameters);
+            //await CreateAuthorizedRequestAsync(VendorDirectFulfillmentOrdersApiUrls.GetOrders, RestSharp.Method.GET, parameter: queryParameters);
+            await CreateAuthorizedRequestAsync(VendorDirectFulfillmentOrdersApiUrls.GetOrders, RestSharp.Method.GET, queryParameters, parameter: searchOrderList);
             var response = await ExecuteRequestAsync<GetOrdersResponse>(RateLimitType.VendorDirectFulfillmentOrdersV1_GetOrders);
             var nextToken = response.Payload?.Pagination?.NextToken;
             orderList.AddRange(response.Payload.Orders);

--- a/Source/FikaAmazonAPI/Services/VendorDirectFulfillmentOrderService.cs
+++ b/Source/FikaAmazonAPI/Services/VendorDirectFulfillmentOrderService.cs
@@ -14,21 +14,21 @@ namespace FikaAmazonAPI.Services
         }
 
 
-        public List<Order> GetOrders(ParameterVendorDirectFulfillmentGetOrders serachOrderList) =>
-            Task.Run(() => GetOrdersAsync(serachOrderList)).ConfigureAwait(false).GetAwaiter().GetResult();
-        public async Task<List<Order>> GetOrdersAsync(ParameterVendorDirectFulfillmentGetOrders serachOrderList)
+        public List<Order> GetOrders(ParameterVendorDirectFulfillmentGetOrders searchOrderList) =>
+            Task.Run(() => GetOrdersAsync(searchOrderList)).ConfigureAwait(false).GetAwaiter().GetResult();
+        public async Task<List<Order>> GetOrdersAsync(ParameterVendorDirectFulfillmentGetOrders searchOrderList)
         {
             var orderList = new List<Order>();
 
-            var queryParameters = serachOrderList.getParameters();
+            var queryParameters = searchOrderList.getParameters();
             await CreateAuthorizedRequestAsync(VendorDirectFulfillmentOrdersApiUrls.GetOrders, RestSharp.Method.GET, parameter: queryParameters);
             var response = await ExecuteRequestAsync<GetOrdersResponse>(RateLimitType.VendorDirectFulfillmentOrdersV1_GetOrders);
             var nextToken = response.Payload?.Pagination?.NextToken;
             orderList.AddRange(response.Payload.Orders);
             while (!string.IsNullOrEmpty(nextToken))
             {
-                serachOrderList.NextToken = nextToken;
-                var orderPayload = GetOrders(serachOrderList);
+                searchOrderList.NextToken = nextToken;
+                var orderPayload = GetOrders(searchOrderList);
                 orderList.AddRange(orderPayload);
             }
             return orderList;


### PR DESCRIPTION
Fixed a spelling error "search".

With vendor orders created before and created after need to be camelCase.

I won't act like I understand it but in VendorDirectFulfillmentOrderService when calling CreateAuthorizedRequestAsync you need to pass queryParameters, parameter: searchOrderList otherwise the parameterOrderList doesn't get added to the request.