### PR TITLE
Updates ReportManager GetCategoriesAsync method with the option to get only root browse nodes

### DIFF
--- a/Source/FikaAmazonAPI/ReportGeneration/ReportManager.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportManager.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using FikaAmazonAPI.AmazonSpApiSDK.Models.Reports;
 using static FikaAmazonAPI.Utils.Constants;
 
 namespace FikaAmazonAPI.ReportGeneration
@@ -205,16 +206,20 @@ namespace FikaAmazonAPI.ReportGeneration
             return Task.Run(() => GetCategoriesAsync()).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        public async Task<List<CategoriesRow>> GetCategoriesAsync()
+        public async Task<List<CategoriesRow>> GetCategoriesAsync(bool rootNodesOnly = false)
         {
-            var path = await GetCategoriesAsync(_amazonConnection);
+            var path = await GetCategoriesAsync(_amazonConnection, rootNodesOnly);
             CategoriesReport report = new CategoriesReport(path, _amazonConnection.RefNumber);
             return report.Data.Node;
         }
 
-        private async Task<string> GetCategoriesAsync(AmazonConnection amazonConnection)
+        private async Task<string> GetCategoriesAsync(AmazonConnection amazonConnection, bool rootNodesOnly)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes.GET_XML_BROWSE_TREE_DATA);
+            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes.GET_XML_BROWSE_TREE_DATA,
+                reportOptions: new ReportOptions
+            {
+                { "RootNodesOnly", rootNodesOnly.ToString() }
+            });
         }
 
         #endregion


### PR DESCRIPTION
Amends the ReportManager GetCategoriesAsync method to have the option to request only root browse nodes