### PR TITLE
Issue with the Uri.IsWellFormedUriString in PostFileDataAsync

### DIFF
--- a/Source/FikaAmazonAPI/Services/FeedService.cs
+++ b/Source/FikaAmazonAPI/Services/FeedService.cs
@@ -245,8 +245,11 @@ namespace FikaAmazonAPI.Services
             byte[] bytes;
             if (Uri.IsWellFormedUriString(contentOrFilePath, UriKind.RelativeOrAbsolute))
                 bytes = File.ReadAllBytes(contentOrFilePath);
+            else if (new Uri(contentOrFilePath).IsFile)
+                bytes = File.ReadAllBytes(new Uri(contentOrFilePath).LocalPath);
             else
                 bytes = System.Text.Encoding.UTF8.GetBytes(contentOrFilePath);
+
             request.ContentType = LinqHelper.GetEnumMemberValue(contentType);
             request.ContentLength = bytes.Length;
             request.Method = "PUT";


### PR DESCRIPTION
Added Uri.IsFile check to PostFileDataAsync. IsWellFormedUriString will fail on a local path. But if you change the local path to a valid Uri then File.ReadAllBytes will fail. Instead added a check for a valid LocalPath then added a fixed File.ReadAllBytes.