### PR TITLE
X_Amzn_RequestId included in AmazonException

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Exceptions/AmazonException.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Exceptions/AmazonException.cs
@@ -1,5 +1,6 @@
 ﻿using RestSharp;
 using System;
+using System.Linq;
 using System.Net;
 
 namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Exceptions
@@ -15,6 +16,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Exceptions
                 Response = new ExceptionResponse();
                 Response.Content = response.Content;
                 Response.ResponseCode = response.StatusCode;
+                Response.X_Amzn_RequestId = (string)response.Headers.Where(x => x.Name == "x-amzn-RequestId").Select(x => x.Value).FirstOrDefault();
             }
         }
 
@@ -72,5 +74,6 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Exceptions
     {
         public string Content { get; set; }
         public HttpStatusCode? ResponseCode { get; set; }
+        public string X_Amzn_RequestId { get; set; }
     }
 }


### PR DESCRIPTION
Recently I opened the [issue](https://github.com/abuzuhri/Amazon-SP-API-CSharp/issues/486) and you said "this error is from Amazon".
So I opened a Support ticket with Amazon Support and they have asked to provide them few things.
Out of those few things, following 2 are related to your Library.

a) The Timestamp (available in the request)
b) The Request ID (available in the response)

Point a:
I have added the **x-amzn-RequestId** in **AmazonException** Class.

Point b:
Please suggest how I can get the Timestamp from request?