### PR TITLE
updte ratelimits next rate

### DIFF
--- a/Source/FikaAmazonAPI/Utils/RateLimits.cs
+++ b/Source/FikaAmazonAPI/Utils/RateLimits.cs
@@ -55,7 +55,8 @@ namespace FikaAmazonAPI.Utils
             if (RequestsSent >= Burst)
             {
                 LastRequest = LastRequest.AddMilliseconds(ratePeriodMs);
-                while (LastRequest >= DateTime.UtcNow) //.AddMilliseconds(-100)
+                var TempLastRequest = LastRequest;
+                while (TempLastRequest >= DateTime.UtcNow) //.AddMilliseconds(-100)
                     Task.Delay(100).Wait();
 
             }


### PR DESCRIPTION
 orgin: the request  will be limited until  final time expires . and then all the requset will be sent out immediately 
 now:Use an temp variable to avoid this

