### PR TITLE
Fixed property naming

### DIFF
--- a/Source/FikaAmazonAPI/Parameter/ProductPricing/ParameterGetCompetitivePricing.cs
+++ b/Source/FikaAmazonAPI/Parameter/ProductPricing/ParameterGetCompetitivePricing.cs
@@ -21,6 +21,6 @@ namespace FikaAmazonAPI.Parameter.ProductPricing
 
                 throw new ArgumentException("You cant request without fill Skus or Asins , you need to fill only of them only");
             }  }
-        public CustomerType? ItemCondition { get; set; }
+        public CustomerType? CustomerType { get; set; }
     }
 }


### PR DESCRIPTION
The CustomerType property in the file ParameterGetCompetitivePricing has the wrong name according to the API reference:

https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-model