### PR TITLE
Order API Method "confirmShipment" throws exception but was successfull

### DIFF
--- a/Source/FikaAmazonAPI/Services/RequestService.cs
+++ b/Source/FikaAmazonAPI/Services/RequestService.cs
@@ -260,7 +260,7 @@ namespace FikaAmazonAPI.Services
 
         protected void ParseResponse(RestResponse response)
         {
-            if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Accepted || response.StatusCode == HttpStatusCode.Created)
+            if (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Accepted || response.StatusCode == HttpStatusCode.Created || response.StatusCode == HttpStatusCode.NoContent)
                 return;
             else if (response.StatusCode == HttpStatusCode.NotFound)
             {


### PR DESCRIPTION
The API Method `confirmShipment` respond with the HTTP status code 204 = NoContent when a request is successfull:

https://developer-docs.amazon.com/sp-api/docs/orders-api-v0-reference#confirmshipment

This response code throws a exception with the message "Amazon Api didn't respond with Okay, see exception for more details".
I added the response Code to the response codes that would be recognized as successfull request.

With this pull request all requests will be successfull when they have a 204 status code. It could also be changed to only allow 204 if the generic type of the method `ExecuteRequestTry` is `NoContent`.