### PR TITLE
Converting UnitMeasurement of Dimension object issue

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/FulfillmentInbound/UnitOfMeasurement.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/FulfillmentInbound/UnitOfMeasurement.cs
@@ -11,6 +11,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Runtime.Serialization;
+using FikaAmazonAPI.Utils;
 
 namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInbound
 {
@@ -19,7 +20,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInbound
     /// </summary>
     /// <value>Indicates the unit of measurement.</value>
 
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(UnitOfMeasurementConverter))]
 
     public enum UnitOfMeasurement
     {

--- a/Source/FikaAmazonAPI/Utils/UnitOfMeasurementConverter.cs
+++ b/Source/FikaAmazonAPI/Utils/UnitOfMeasurementConverter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInbound;
+
+namespace FikaAmazonAPI.Utils
+{
+    class UnitOfMeasurementConverter : StringEnumConverter
+    {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            string unitOfMeasurementString = reader.Value.ToString();
+            if (unitOfMeasurementString.Equals("in", StringComparison.OrdinalIgnoreCase))
+                return UnitOfMeasurement.Inches;
+            else
+                return (UnitOfMeasurement)Enum.Parse(typeof(UnitOfMeasurement), unitOfMeasurementString, true);
+        }
+    }
+}


### PR DESCRIPTION
For FulfillmentInbound getTransportDetails endpoint,
Amazon returns "In" instead of "Inches" 
for 'payload.TransportContent.TransportDetails.PartneredSmallParcelData.PackageList[0].Dimensions.Unit

So an exception occurs when deserializing amazon response to Fika Api object.