### PR TITLE
Additional Error cases for API response

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Exceptions/AmazonException.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Exceptions/AmazonException.cs
@@ -59,6 +59,22 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Exceptions
         }
     }
 
+    public class AmazonInternalErrorException : AmazonException
+    {
+        public AmazonInternalErrorException(string msg, RestResponse response = null) : base(msg, response)
+        {
+
+        }
+    }
+
+    public class AmazonBadRequestException : AmazonException
+    {
+        public AmazonBadRequestException(string msg, RestResponse response = null) : base(msg, response)
+        {
+
+        }
+    }
+
     public class AmazonProcessingReportDeserializeException : AmazonException
     {
         public string ReportContent { get; set; }
@@ -66,7 +82,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Exceptions
         {
             ReportContent = reportContent;
         }
-    }
+    } 
 
     public class ExceptionResponse
     {

--- a/Source/FikaAmazonAPI/Services/RequestService.cs
+++ b/Source/FikaAmazonAPI/Services/RequestService.cs
@@ -1,4 +1,4 @@
-﻿using FikaAmazonAPI.AmazonSpApiSDK.Models.Exceptions;
+using FikaAmazonAPI.AmazonSpApiSDK.Models.Exceptions;
 using FikaAmazonAPI.AmazonSpApiSDK.Models.Filters;
 using FikaAmazonAPI.AmazonSpApiSDK.Models.Token;
 using FikaAmazonAPI.AmazonSpApiSDK.Runtime;
@@ -286,9 +286,16 @@ namespace FikaAmazonAPI.Services
                             throw new AmazonInvalidInputException(error.Message, response);
                         case "QuotaExceeded":
                             throw new AmazonQuotaExceededException(error.Message, response);
+                        case "InternalFailure":
+                            throw new AmazonInternalErrorException(error.Message, response);
                     }
 
                 }
+            }
+
+            if (response.StatusCode == HttpStatusCode.BadRequest)
+            {
+                throw new AmazonBadRequestException("BadRequest see https://developer-docs.amazon.com/sp-api/changelog/api-request-validation-for-400-errors-with-html-response for advice", response);
             }
 
             throw new AmazonException("Amazon Api didn't respond with Okay, see exception for more details", response);


### PR DESCRIPTION
So we can differentiate between 500 transient errors, 400 bad request errors and other unknown errors.