### PR TITLE
Add RateLimitType in CreateRestrictedDataTokenAsync method

### DIFF
--- a/Source/FikaAmazonAPI/Services/RequestService.cs
+++ b/Source/FikaAmazonAPI/Services/RequestService.cs
@@ -405,7 +405,7 @@ namespace FikaAmazonAPI.Services
         public async Task<CreateRestrictedDataTokenResponse> CreateRestrictedDataTokenAsync(CreateRestrictedDataTokenRequest createRestrictedDataTokenRequest, CancellationToken cancellationToken = default)
         {
             await CreateAuthorizedRequestAsync(TokenApiUrls.RestrictedDataToken, RestSharp.Method.Post, postJsonObj: createRestrictedDataTokenRequest, cancellationToken: cancellationToken);
-            var response = await ExecuteRequestAsync<CreateRestrictedDataTokenResponse>(cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<CreateRestrictedDataTokenResponse>(RateLimitType.Token_CreateRestrictedDataToken, cancellationToken: cancellationToken);
             return response;
         }
     }


### PR DESCRIPTION
Fixed the issue https://github.com/abuzuhri/Amazon-SP-API-CSharp/issues/575
CreateRestrictedDataTokenAsync is calling ExecuteRequestAsync method, which catches AmazonQuotaExceededException exception. 
In case there is AmazonQuotaExceededException exception, the current code is trying to use "AmazonCredential.UsagePlansTimings[rateLimitType]" at line 217, which is throwing again error, because the current code is using default rate limit which is not available in RateLimitType