### PR TITLE
Added possibility to use correct encoding for directly constructor usage

### DIFF
--- a/Source/FikaAmazonAPI/ReportGeneration/ProductsReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ProductsReport.cs
@@ -1,17 +1,18 @@
 ﻿using FikaAmazonAPI.ReportGeneration.ReportDataTable;
 using System.Collections.Generic;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
     public class ProductsReport
     {
         public List<ProductsRow> Data { get; set; } = new List<ProductsRow>();
-        public ProductsReport(string path, string refNumber)
+        public ProductsReport(string path, string refNumber, Encoding encoding = default)
         {
             if (string.IsNullOrEmpty(path))
                 return;
 
-            var table = Table.ConvertFromCSV(path);
+            var table = Table.ConvertFromCSV(path, encoding: encoding);
 
             List<ProductsRow> values = new List<ProductsRow>();
             foreach (var row in table.Rows)

--- a/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
@@ -48,9 +48,9 @@ namespace FikaAmazonAPI.ReportGeneration.ReportDataTable
             this.header = header;
         }
 
-        public static Table ConvertFromCSV(string path, char separator = '\t')
+        public static Table ConvertFromCSV(string path, char separator = '\t', Encoding encoding = default)
         {
-            var lines = File.ReadAllLines(path);
+            var lines = File.ReadAllLines(path, encoding ?? Encoding.UTF8);
 
             var table = new Table(lines.First().Split(separator));
 


### PR DESCRIPTION
By default in .NET uses UTF-8 encoding for reading all lines, but there are some cases when we should get information about merchant listings and parse file in different encoding like windows-1252, so optional parameter could fix this to use constractor directly and parse necessary merchant listings report type