### PR TITLE
RestockDate in InventoryMessage takes only date part with no time

### DIFF
--- a/Source/FikaAmazonAPI/ConstructFeed/Messages/InventoryMessage.cs
+++ b/Source/FikaAmazonAPI/ConstructFeed/Messages/InventoryMessage.cs
@@ -12,7 +12,7 @@ namespace FikaAmazonAPI.ConstructFeed.Messages
         public bool? Available { get; set; }
         public InventoryLookup? Lookup { get; set; }
         public int? Quantity { get; set; }
-
+        [XmlElement(DataType = "date")]
         public DateTime? RestockDate { get; set; }
 
         public string FulfillmentLatency { get; set; }


### PR DESCRIPTION
added an extra attribute to fit to the expected date format.