### PR TITLE
Update to RestSharp v110.2.0

### DIFF
--- a/Source/FikaAmazonAPI.SampleCode/FikaAmazonAPI.SampleCode.csproj
+++ b/Source/FikaAmazonAPI.SampleCode/FikaAmazonAPI.SampleCode.csproj
@@ -27,8 +27,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="RestSharp" Version="108.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />

--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Runtime/RestClientSingleton.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Runtime/RestClientSingleton.cs
@@ -39,7 +39,8 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Runtime
             {
                 BaseUrl = baseUri,
             };
-            return new RestClient(_httpClient, restClientOption).UseNewtonsoftJson();
+            return new RestClient(_httpClient, restClientOption,
+                configureSerialization: s => s.UseNewtonsoftJson());
         }
     }
 }

--- a/Source/FikaAmazonAPI/FikaAmazonAPI.csproj
+++ b/Source/FikaAmazonAPI/FikaAmazonAPI.csproj
@@ -39,9 +39,9 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.7.100.52" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="RestSharp" Version="108.0.3" />
-    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="108.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
     <PackageReference Include="StandardSocketsHttpHandler" Version="2.2.0.4" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/Source/FikaAmazonAPI/Services/RequestService.cs
+++ b/Source/FikaAmazonAPI/Services/RequestService.cs
@@ -58,7 +58,9 @@ namespace FikaAmazonAPI.Services
         {
             if (string.IsNullOrWhiteSpace(AmazonCredential.ProxyAddress))
             {
-                RequestClient = new RestClient(ApiBaseUrl);
+                var options = new RestClientOptions(ApiBaseUrl);
+                RequestClient = new RestClient(options,
+                    configureSerialization: s => s.UseNewtonsoftJson());
             }
             else
             {
@@ -70,10 +72,10 @@ namespace FikaAmazonAPI.Services
                     }
                 };
 
-                RequestClient = new RestClient(options);
+                RequestClient = new RestClient(options,
+                    configureSerialization: s => s.UseNewtonsoftJson());
             }
 
-            RequestClient.UseNewtonsoftJson();
             Request = new RestRequest(url, method);
         }
 


### PR DESCRIPTION
Updated to RestSharp v110.2.0. If you don't also update RestSharp.Serializers.NewtonsoftJson to the same version you get the error in issue #588 . After updating both you get errors where RestClient.UseNewtonsoftJson() has been removed. Changed RestClient initializations to new format.