### PR TITLE
Added  new DeemedResellerCategoryEnum value - NG_VOEC

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/OrderItem.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/OrderItem.cs
@@ -91,7 +91,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Orders
             /// Enum JE_VOEC for value: JE_VOEC
             /// </summary>
             [EnumMember(Value = "NG_VOEC")]
-            NG_VOEC = 9
+            NG_VOEC = 10
 
         }
 

--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/OrderItem.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/OrderItem.cs
@@ -85,7 +85,14 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Orders
             /// Enum JE_VOEC for value: JE_VOEC
             /// </summary>
             [EnumMember(Value = "JE_VOEC")]
-            JE_VOEC = 9
+            JE_VOEC = 9,
+
+            /// <summary>
+            /// Enum JE_VOEC for value: JE_VOEC
+            /// </summary>
+            [EnumMember(Value = "NG_VOEC")]
+            NG_VOEC = 9
+
         }
 
         /// <summary>


### PR DESCRIPTION
Repairing error:

Newtonsoft.Json.JsonSerializationException: 'Error converting value "NG_VOEC" to type 'System.Nullable`1[FikaAmazonAPI.AmazonSpApiSDK.Models.Orders.OrderItem+DeemedResellerCategoryEnum]'. Path 'payload.OrderItems[0].DeemedResellerCategory', line 1, position 922.'