### PR TITLE
ReportService - GetReportsByNextToken if nextToken is empty request first page

### DIFF
--- a/Source/FikaAmazonAPI/Services/ReportService.cs
+++ b/Source/FikaAmazonAPI/Services/ReportService.cs
@@ -94,9 +94,15 @@ namespace FikaAmazonAPI.Services
             Task.Run(() => GetReportsByNextTokenAsync(parameterReportList)).ConfigureAwait(false).GetAwaiter().GetResult();
         public async Task<GetReportsResponseV00> GetReportsByNextTokenAsync(ParameterReportList parameterReportList, CancellationToken cancellationToken = default)
         {
-            var parameterReportListNew = new ParameterReportList();
-            parameterReportListNew.nextToken = parameterReportList.nextToken;
-            var parameters = parameterReportListNew.getParameters();
+	    List<KeyValuePair<string, string>> parameters = null;
+	    if(string.IsNullOrEmpty(parameterReportList.nextToken))
+                parameters = parameterReportList.getParameters();
+	    else
+            {
+                var parameterReportListNew = new ParameterReportList();
+                parameterReportListNew.nextToken = parameterReportList.nextToken;
+                parameters = parameterReportListNew.getParameters();
+            }
 
             await CreateAuthorizedRequestAsync(ReportApiUrls.GetReports, RestSharp.Method.Get, parameters, cancellationToken: cancellationToken);
             var response = await ExecuteRequestAsync<GetReportsResponseV00>(RateLimitType.Report_GetReports, cancellationToken);


### PR DESCRIPTION
ReportService - GetReportsByNextToken if nextToken is empty request first page

Currently, there is the `public GetReportsByNextToken` method so clients can call to get the next page of reports, this is an important method cause - unlike the `ReportService.GetReportsAsync` method which loops until reports are retrieved -  this gives control to the user whether to continue asking for next page of reports or to stop. 
However, there is no (public method) way to retrieve the initial page of reports. This revision changes the code in `ReportService.GetReportsByNextTokenAsync` such that if the ParameterReportList.nextToken parameter is empty the first page will be retrieved. 

Note: We may want to rename this method to: "GetReportsPage" ?