### PR TITLE
Dont block when waiting a rate limit

### DIFF
--- a/Source/FikaAmazonAPI/Services/RequestService.cs
+++ b/Source/FikaAmazonAPI/Services/RequestService.cs
@@ -214,7 +214,7 @@ namespace FikaAmazonAPI.Services
 
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    AmazonCredential.UsagePlansTimings[rateLimitType].Delay();
+                    await AmazonCredential.UsagePlansTimings[rateLimitType].Delay();
                     tryCount++;
                 }
             }

--- a/Source/FikaAmazonAPI/Utils/RateLimits.cs
+++ b/Source/FikaAmazonAPI/Utils/RateLimits.cs
@@ -79,9 +79,9 @@ namespace FikaAmazonAPI.Utils
             Rate = rate;
         }
 
-        internal void Delay()
+        internal Task Delay()
         {
-            Task.Delay(GetRatePeriodMs()).Wait();
+            return Task.Delay(GetRatePeriodMs());
         }
     }
 }


### PR DESCRIPTION
We don't have to block thread when waiting amazon rate limit so when can use await Task.Delay instead of .Wait
ref: https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#avoid-using-taskresult-and-taskwait