### PR TITLE
Fixed bugs getting orders with PII and Debug logging. Added getAdditionalInputs to the Shipping API v2.

### DIFF
--- a/Source/FikaAmazonAPI.SampleCode/FulFillmentInboundv20240320Sample .cs
+++ b/Source/FikaAmazonAPI.SampleCode/FulFillmentInboundv20240320Sample .cs
@@ -1,4 +1,6 @@
-﻿namespace FikaAmazonAPI.SampleCode
+﻿using FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320;
+
+namespace FikaAmazonAPI.SampleCode
 {
     public class FulFillmentInboundv20240320Sample
     {
@@ -17,7 +19,7 @@
             oCreateInboundShipmentPlanRequest.DestinationMarketplaces = new List<string> {amazonConnection.GetCurrentMarketplace.ID};
 
 
-            oCreateInboundShipmentPlanRequest.SourceAddress = new FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320.Address();
+            oCreateInboundShipmentPlanRequest.SourceAddress = new AddressInput();  // FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320.Address();
             oCreateInboundShipmentPlanRequest.SourceAddress.AddressLine1 = "Add";
             oCreateInboundShipmentPlanRequest.SourceAddress.AddressLine2 = "ADD2";
             oCreateInboundShipmentPlanRequest.SourceAddress.City = "City";

--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ShippingV2/GetAdditionalInputsRequest.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ShippingV2/GetAdditionalInputsRequest.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace FikaAmazonAPI.AmazonSpApiSDK.Models.ShippingV2
+{
+    [DataContract]
+    public class GetAdditionalInputsRequest
+    {
+        /// <summary>
+        /// The request token returned in the response to the getRates operation.
+        /// </summary>
+        [DataMember(Name = "requestToken", EmitDefaultValue = false)]
+        [JsonProperty(PropertyName = "requestToken")]
+        public string RequestToken { get; set; }
+
+        /// <summary>
+        /// The rate identifier for the shipping offering (rate) returned in the response to the getRates operation.
+        /// </summary>
+        [DataMember(Name = "rateId", EmitDefaultValue = false)]
+        [JsonProperty(PropertyName = "rateId")]
+        public string RateId { get; set; }
+
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class " + nameof(GetAdditionalInputsRequest) + " {\n");
+            sb.Append($"  {nameof(RequestToken)}: ").Append(RequestToken).Append("\n");
+            sb.Append($"  {nameof(RateId)}: ").Append(RateId).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Get the JSON string presentation of the object
+        /// </summary>
+        /// <returns>JSON string presentation of the object</returns>
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+    }
+
+}

--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ShippingV2/GetAdditionalInputsResponse.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ShippingV2/GetAdditionalInputsResponse.cs
@@ -1,44 +1,47 @@
-using System;
-using System.Text;
-using System.Collections;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using System.Runtime.Serialization;
+using System.Text;
 
-namespace FikaAmazonAPI.AmazonSpApiSDK.Models.ShippingV2 {
-
-  /// <summary>
-  /// The response schema for the getAdditionalInputs operation.
-  /// </summary>
-  [DataContract]
-  public class GetAdditionalInputsResponse {
-    /// <summary>
-    /// Gets or Sets Payload
-    /// </summary>
-    [DataMember(Name="payload", EmitDefaultValue=false)]
-    [JsonProperty(PropertyName = "payload")]
-    public GetAdditionalInputsResult Payload { get; set; }
-
+namespace FikaAmazonAPI.AmazonSpApiSDK.Models.ShippingV2
+{
 
     /// <summary>
-    /// Get the string presentation of the object
+    /// The response schema for the getAdditionalInputs operation.
     /// </summary>
-    /// <returns>String presentation of the object</returns>
-    public override string ToString()  {
-      var sb = new StringBuilder();
-      sb.Append("class GetAdditionalInputsResponse {\n");
-      sb.Append("  Payload: ").Append(Payload).Append("\n");
-      sb.Append("}\n");
-      return sb.ToString();
+    [DataContract]
+    public class GetAdditionalInputsResponse
+    {
+        /// <summary>
+        /// Gets or Sets Payload
+        /// See: https://developer-docs.amazon.com/amazon-shipping/docs/shipping-api-v2-reference#getadditionalinputsresponse
+        /// </summary>
+        [DataMember(Name = "payload", EmitDefaultValue = false)]
+        [JsonProperty(PropertyName = "payload", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+        public GetAdditionalInputsResult Payload { get; set; }
+
+
+        /// <summary>
+        /// Get the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class GetAdditionalInputsResponse {\n");
+            sb.Append("  Payload: ").Append(Payload).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Get the JSON string presentation of the object
+        /// </summary>
+        /// <returns>JSON string presentation of the object</returns>
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+
     }
 
-    /// <summary>
-    /// Get the JSON string presentation of the object
-    /// </summary>
-    /// <returns>JSON string presentation of the object</returns>
-    public string ToJson() {
-      return JsonConvert.SerializeObject(this, Formatting.Indented);
-    }
-
-}
 }

--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ShippingV2/GetAdditionalInputsResult.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ShippingV2/GetAdditionalInputsResult.cs
@@ -11,26 +11,29 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.ShippingV2 {
   /// The JSON schema to use to provide additional inputs when required to purchase a shipping offering.
   /// </summary>
   [DataContract]
-  public class GetAdditionalInputsResult : Dictionary<String, Object> {
+  public class GetAdditionalInputsResult : Dictionary<String, Object> 
+  {
 
     /// <summary>
     /// Get the string presentation of the object
     /// </summary>
     /// <returns>String presentation of the object</returns>
-    public override string ToString()  {
-      var sb = new StringBuilder();
-      sb.Append("class GetAdditionalInputsResult {\n");
-      sb.Append("}\n");
-      return sb.ToString();
+    public override string ToString()  
+    {
+        var sb = new StringBuilder();
+        sb.Append("class GetAdditionalInputsResult {\n");
+        sb.Append("}\n");
+        return sb.ToString();
     }
 
     /// <summary>
     /// Get the JSON string presentation of the object
     /// </summary>
     /// <returns>JSON string presentation of the object</returns>
-    public  new string ToJson() {
-      return JsonConvert.SerializeObject(this, Formatting.Indented);
+    public string ToJson() 
+    {
+        return JsonConvert.SerializeObject(this, Formatting.Indented);
     }
 
-}
+  }
 }

--- a/Source/FikaAmazonAPI/FikaAmazonAPI.csproj
+++ b/Source/FikaAmazonAPI/FikaAmazonAPI.csproj
@@ -7,9 +7,9 @@
     <Product>CSharp Amazon Sp API</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>8.0</LangVersion>
-    <Version>1.7.24</Version>
-    <AssemblyVersion>1.7.24</AssemblyVersion>
-    <FileVersion>1.7.24</FileVersion>
+    <Version>1.7.25.1</Version>
+    <AssemblyVersion>1.7.25.1</AssemblyVersion>
+    <FileVersion>1.7.25.1</FileVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/abuzuhri/Amazon-SP-API-CSharp</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Source/FikaAmazonAPI/Services/ApiUrls.cs
+++ b/Source/FikaAmazonAPI/Services/ApiUrls.cs
@@ -223,6 +223,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Services
             {
                 get => $"{_resourceBaseUrl}/shipments";
             }
+            public static string GetAdditionalInputs(string requestToken, string rateId) => $"{_resourceBaseUrl}/shipments/additionalInputs/schema?requestToken={requestToken}&rateId={rateId}";            
             public static string GetTracking(string carrierId, string trackingId) => $"{_resourceBaseUrl}/tracking?carrierId={carrierId}&trackingId={trackingId}";
             public static string GetShipmentDocuments(string shipmentId, string packageClientReferenceId, string format) => $"{_resourceBaseUrl}/shipments/{shipmentId}/documents?packageClientReferenceId={packageClientReferenceId}&format={format}";
             public static string CancelShipment(string shipmentId) => $"{_resourceBaseUrl}/shipments/{shipmentId}/cancel";

--- a/Source/FikaAmazonAPI/Services/OrderService.cs
+++ b/Source/FikaAmazonAPI/Services/OrderService.cs
@@ -136,11 +136,9 @@ namespace FikaAmazonAPI.Services
 
             return orderList;
         }
-
-       
+        
         public async Task<OrdersList> GetGetOrdersByNextTokenAsync(string nextToken, ParameterOrderList searchOrderList)
         {
-
             var parameterOrderList = new ParameterOrderList
             {
                 MarketplaceIds = searchOrderList.MarketplaceIds,
@@ -151,10 +149,13 @@ namespace FikaAmazonAPI.Services
 
             List<KeyValuePair<string, string>> queryParameters = parameterOrderList.getParameters();
            
-            await CreateAuthorizedRequestAsync(OrdersApiUrls.Orders, RestSharp.Method.Get, queryParameters);
+            await CreateAuthorizedRequestAsync(OrdersApiUrls.Orders, RestSharp.Method.Get, queryParameters, parameter: parameterOrderList);
+            
             var response = await ExecuteRequestAsync<GetOrdersResponse>(Utils.RateLimitType.Order_GetOrders);
+            
             return response.Payload;
         }
+        
         public OrdersList GetOrdersList(ParameterOrderList searchOrderList) =>
             Task.Run(() => GetOrdersListAsync(searchOrderList)).ConfigureAwait(false).GetAwaiter().GetResult();
         public async Task<OrdersList> GetOrdersListAsync(ParameterOrderList searchOrderList)

--- a/Source/FikaAmazonAPI/Services/RequestService.cs
+++ b/Source/FikaAmazonAPI/Services/RequestService.cs
@@ -9,6 +9,7 @@ using RestSharp;
 using RestSharp.Serializers.NewtonsoftJson;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -179,10 +180,11 @@ namespace FikaAmazonAPI.Services
                     responseUri = response.ResponseUri,
                     errorMessage = response.ErrorMessage,
                 };
-                Console.WriteLine("\n\n");
-                Console.WriteLine(string.Format("Request completed, \nRequest: {0} \n\nResponse: {1}",
-                    JsonConvert.SerializeObject(requestToLog),
-                    JsonConvert.SerializeObject(responseToLog)));
+
+                Debug.WriteLine("\n\n---------------------------------------------------------\n");
+                string msg = string.Format("Request completed, \nRequest: {0} \n\nResponse: {1}", requestToLog, responseToLog);
+
+                Debug.WriteLine(msg);
             }
         }
 

--- a/Source/FikaAmazonAPI/Services/ShippingServiceV2.cs
+++ b/Source/FikaAmazonAPI/Services/ShippingServiceV2.cs
@@ -47,6 +47,17 @@ namespace FikaAmazonAPI.Services
             return null;
         }
 
+        public GetAdditionalInputsResult GetAdditionalInputs(GetAdditionalInputsRequest getRatesRequest) =>
+            Task.Run(() => GetAdditionalInputsAsync(getRatesRequest)).ConfigureAwait(false).GetAwaiter().GetResult();
+        public async Task<GetAdditionalInputsResult> GetAdditionalInputsAsync(GetAdditionalInputsRequest getRatesRequest, CancellationToken cancellationToken = default)
+        {
+            await CreateAuthorizedRequestAsync(ShippingApiV2Urls.GetAdditionalInputs(getRatesRequest.RequestToken, getRatesRequest.RateId), RestSharp.Method.Get, cancellationToken: cancellationToken);
+            var response = await ExecuteRequestAsync<GetAdditionalInputsResponse>(RateLimitType.ShippingV2_GetAdditionalInputs, cancellationToken);
+            if (response != null && response.Payload != null)
+                return response.Payload;
+            return null;
+        }
+
         public GetTrackingResult GetTracking(string carrierId, string trackingId) =>
             Task.Run(() => GetTrackingAsync(carrierId, trackingId)).ConfigureAwait(false).GetAwaiter().GetResult();
         public async Task<GetTrackingResult> GetTrackingAsync(string carrierId, string trackingId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
1. When calling the `OrderService.GetGetOrdersByNextToken()` method, it wasn't adding a [PII](https://developer-docs.amazon.com/sp-api/docs/tokens-api-use-case-guide#tutorial-get-authorization-to-access-restricted-report-types-with-pii-information) Token (only the default Normal Token). 
2. The `RequestService.LogRequest()` method wasn't logging to the Output Debug window in Visual Studio. 
3. Added the missing `ShippingServiceV2.GetAdditionalInputs()` API call needed in a case where Amazon requires [additional input](https://developer-docs.amazon.com/amazon-shipping/docs/shipping-api-v2-reference#get-shippingv2shipmentsadditionalinputsschema) when [purchasing a shipment](https://developer-docs.amazon.com/amazon-shipping/docs/workflow-for-creating-a-shipment) rate. 
