### PR TITLE
fix: XML Property name

### DIFF
--- a/Source/FikaAmazonAPI/ConstructFeed/Messages/OrderAdjustmentMessage.cs
+++ b/Source/FikaAmazonAPI/ConstructFeed/Messages/OrderAdjustmentMessage.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Xml.Serialization;
 using FikaAmazonAPI.ConstructFeed.Messages;
 using static FikaAmazonAPI.ConstructFeed.BaseXML;
@@ -86,7 +86,7 @@ namespace FikaAmazonAPI.ConstructFeed.Messages
         [XmlElement(ElementName = "Type")]
         public string DirectPaymentType { get; set; }
 
-        [XmlElement(ElementName = "AdjustmentCurrencyAmount")]
+        [XmlElement(ElementName = "Amount")]
         public CurrencyAmount Amount { get; set; }
     }
 


### PR DESCRIPTION
Minor adjustment to OrderAdjustment/`POST_PAYMENT_ADJUSTMENT_DATA` feed property name to match the one within the [docs](https://images-na.ssl-images-amazon.com/images/G/01/rainier/help/xsd/release_4_1/OrderAdjustment.xsd)

#

![image](https://github.com/user-attachments/assets/314d3204-3d8d-4b35-a3c4-c57b686734de)
