### PR TITLE
Added fallback property for FulfillmentChannel property when json property name does not match

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ListingsItems/FulfillmentAvailability.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/ListingsItems/FulfillmentAvailability.cs
@@ -56,6 +56,22 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.ListingsItems
         public string FulfillmentChannelCode { get; set; }
 
         /// <summary>
+        /// This property is used like fallback property when property 'FulfillmentChannelCode' is not deserialized by data member name
+        /// </summary>
+        private string apiFulfillmentChannelCode;
+        [DataMember(Name = "fulfillmentChannelCode", EmitDefaultValue = false, IsRequired = false)]
+        private string ApiFullfilmentChannelCode
+        {
+            get => apiFulfillmentChannelCode;
+            set
+            {
+                apiFulfillmentChannelCode = value;
+                if (string.IsNullOrEmpty(FulfillmentChannelCode))
+                    FulfillmentChannelCode = value;
+            }
+        }
+
+        /// <summary>
         /// The quantity of the item you are making available for sale.
         /// </summary>
         /// <value>The quantity of the item you are making available for sale.</value>


### PR DESCRIPTION
There was a change in #745 where DataMember attribute Name property was changed. As far as I know it was changed for to correctly deserialize 'Listings Items' feeds JSON but if JSON comes from [API getListingsItem](https://sellingpartnerapi-na.amazon.com/listings/2021-08-01/items/{sellerId}/{sku}) it fails to deserialize correctly because that JSON contains property name _fulfillmentChannelCode_ instead of _fulfillment_channel_code_ . So I decided to add 'fallback' private property.