### PR TITLE
Fix for https://github.com/abuzuhri/Amazon-SP-API-CSharp/issues/795

### DIFF
--- a/Source/FikaAmazonAPI.SampleCode/FulFillmentInboundSample.cs
+++ b/Source/FikaAmazonAPI.SampleCode/FulFillmentInboundSample.cs
@@ -75,7 +75,7 @@ namespace FikaAmazonAPI.SampleCode
             var labelParams = new ParameterGetLabels()
             {
                 PageType = PageType.PackageLabel_Letter_6,
-                shipmentId = shipmentId,
+                ShipmentId = shipmentId,
                 LabelType = LabelType.SELLER_LABEL,
                 PageSize = boxCount
             };

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/ParameterGetLabels.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/ParameterGetLabels.cs
@@ -7,7 +7,7 @@ namespace FikaAmazonAPI.Parameter.FulFillmentInbound
     public class ParameterGetLabels : ParameterBased
     {
         public string MarketplaceId { get; set; }
-        public string shipmentId { get; set; }
+        public string ShipmentId { get; set; }
         public PageType PageType { get; set; }
         public LabelType LabelType { get; set; }
         public int? NumberOfPackages { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListPrepDetails.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListPrepDetails.cs
@@ -5,8 +5,8 @@ namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
     public class ParameterListPrepDetails : ParameterBased
     {
-        public string marketplaceId { get; set; }
+        public string MarketplaceId { get; set; }
 
-        public ICollection<string> mskus { get; set; }
+        public ICollection<string> Mskus { get; set; }
     }
 }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListShipmentBase.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListShipmentBase.cs
@@ -4,6 +4,6 @@
     { 
         public string InboundPlanId { get; set; }
         public string ShipmentId { get; set; }
-        public string paginationToken { get; set; }
+        public string PaginationToken { get; set; }
     }
 }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListTransportationOptions.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListTransportationOptions.cs
@@ -2,8 +2,8 @@
 {
     public class ParameterListTransportationOptions : PaginationParameter
     {
-        public string placementOptionId { get; set; }
-        public string shipmentId { get; set; }
-        public string paginationToken { get; set; }
+        public string PlacementOptionId { get; set; }
+        public string ShipmentId { get; set; }
+        public string PaginationToken { get; set; }
     }
 }

--- a/Source/FikaAmazonAPI/Parameter/ParameterBased.cs
+++ b/Source/FikaAmazonAPI/Parameter/ParameterBased.cs
@@ -76,8 +76,8 @@ namespace FikaAmazonAPI.Search
                         output = JsonConvert.SerializeObject(value, settings);
                     }
 
-
-                    var propName = p.Name;
+                    // Convert to cammelCase to avoid issues with properties not being properly mapped
+                    var propName = char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1);
 
                     queryParameters.Add(new KeyValuePair<string, string>(propName, output));
                 }

--- a/Source/FikaAmazonAPI/Services/FulFillmentInboundService.cs
+++ b/Source/FikaAmazonAPI/Services/FulFillmentInboundService.cs
@@ -194,7 +194,7 @@ namespace FikaAmazonAPI.Services
         public async Task<LabelDownloadURL> GetLabelsAsync(ParameterGetLabels parameterGetLabels, CancellationToken cancellationToken = default)
         {
             var parameter = parameterGetLabels.getParameters();
-            await CreateAuthorizedRequestAsync(FulFillmentInboundApiUrls.GetLabels(parameterGetLabels.shipmentId), RestSharp.Method.Get, parameter, cancellationToken: cancellationToken);
+            await CreateAuthorizedRequestAsync(FulFillmentInboundApiUrls.GetLabels(parameterGetLabels.ShipmentId), RestSharp.Method.Get, parameter, cancellationToken: cancellationToken);
 
             var response = await ExecuteRequestAsync<GetLabelsResponse>(RateLimitType.FulFillmentInbound_GetLabels, cancellationToken);
             if (response != null && response.Payload != null)

--- a/Source/FikaAmazonAPI/Services/FulFillmentInboundServicev20240320.cs
+++ b/Source/FikaAmazonAPI/Services/FulFillmentInboundServicev20240320.cs
@@ -463,7 +463,7 @@ namespace FikaAmazonAPI.Services
                 var nextToken = response.Pagination.NextToken;
                 while (!string.IsNullOrEmpty(nextToken) && (!parameterListShipmentBase.maxPages.HasValue || totalPages < parameterListShipmentBase.maxPages.Value))
                 {
-                    parameterListShipmentBase.paginationToken = nextToken;
+                    parameterListShipmentBase.PaginationToken = nextToken;
                     var getItemNextPage = await ListShipmentBoxesByNextTokenAsync(parameterListShipmentBase, cancellationToken);
                     list.AddRange(getItemNextPage.Boxes);
                     nextToken = getItemNextPage.Pagination?.NextToken;
@@ -513,7 +513,7 @@ namespace FikaAmazonAPI.Services
                 var nextToken = response.Pagination.NextToken;
                 while (!string.IsNullOrEmpty(nextToken) && (!parameterListShipmentBase.maxPages.HasValue || totalPages < parameterListShipmentBase.maxPages.Value))
                 {
-                    parameterListShipmentBase.paginationToken = nextToken;
+                    parameterListShipmentBase.PaginationToken = nextToken;
                     var getItemNextPage = await ListShipmentContentUpdatePreviewsByNextTokenAsync(parameterListShipmentBase, cancellationToken);
                     list.AddRange(getItemNextPage.ContentUpdatePreviews);
                     nextToken = getItemNextPage.Pagination?.NextToken;
@@ -596,7 +596,7 @@ namespace FikaAmazonAPI.Services
                 var nextToken = response.Pagination.NextToken;
                 while (!string.IsNullOrEmpty(nextToken) && (!parameterListShipmentBase.maxPages.HasValue || totalPages < parameterListShipmentBase.maxPages.Value))
                 {
-                    parameterListShipmentBase.paginationToken = nextToken;
+                    parameterListShipmentBase.PaginationToken = nextToken;
                     var getItemNextPage = await ListDeliveryWindowOptionsByNextTokenAsync(parameterListShipmentBase, cancellationToken);
                     list.AddRange(getItemNextPage.DeliveryWindowOptions);
                     nextToken = getItemNextPage.Pagination?.NextToken;
@@ -646,7 +646,7 @@ namespace FikaAmazonAPI.Services
                 var nextToken = response.Pagination.NextToken;
                 while (!string.IsNullOrEmpty(nextToken) && (!parameterListShipmentBase.maxPages.HasValue || totalPages < parameterListShipmentBase.maxPages.Value))
                 {
-                    parameterListShipmentBase.paginationToken = nextToken;
+                    parameterListShipmentBase.PaginationToken = nextToken;
                     var getItemNextPage = await ListShipmentItemsByNextTokenAsync(parameterListShipmentBase, cancellationToken);
                     list.AddRange(getItemNextPage.Items);
                     nextToken = getItemNextPage.Pagination?.NextToken;
@@ -700,7 +700,7 @@ namespace FikaAmazonAPI.Services
                 var nextToken = response.Pagination.NextToken;
                 while (!string.IsNullOrEmpty(nextToken) && (!parameterListShipmentBase.maxPages.HasValue || totalPages < parameterListShipmentBase.maxPages.Value))
                 {
-                    parameterListShipmentBase.paginationToken = nextToken;
+                    parameterListShipmentBase.PaginationToken = nextToken;
                     var getItemNextPage = await ListShipmentPalletsByNextTokenAsync(parameterListShipmentBase, cancellationToken);
                     list.AddRange(getItemNextPage.Pallets);
                     nextToken = getItemNextPage.Pagination?.NextToken;
@@ -751,7 +751,7 @@ namespace FikaAmazonAPI.Services
                 var nextToken = response.Pagination.NextToken;
                 while (!string.IsNullOrEmpty(nextToken) && (!parameterListShipmentBase.maxPages.HasValue || totalPages < parameterListShipmentBase.maxPages.Value))
                 {
-                parameterListShipmentBase.paginationToken = nextToken;
+                parameterListShipmentBase.PaginationToken = nextToken;
                     var getItemNextPage = await GetSelfShipAppointmentSlotsByNextTokenAsync(parameterListShipmentBase, cancellationToken);
                     list.Add(getItemNextPage.SelfShipAppointmentSlotsAvailability);
                     nextToken = getItemNextPage.Pagination?.NextToken;
@@ -846,7 +846,7 @@ namespace FikaAmazonAPI.Services
                 var nextToken = response.Pagination.NextToken;
                 while (!string.IsNullOrEmpty(nextToken) && (!parameterListTransportationOptions.maxPages.HasValue || totalPages < parameterListTransportationOptions.maxPages.Value))
                 {
-                    parameterListTransportationOptions.paginationToken = nextToken;
+                    parameterListTransportationOptions.PaginationToken = nextToken;
                     var getItemNextPage = await ListTransportationOptionsByNextTokenAsync(inboundPlanId, parameterListTransportationOptions, cancellationToken);
                     list.AddRange(getItemNextPage.TransportationOptions);
                     nextToken = getItemNextPage.Pagination?.NextToken;
@@ -929,9 +929,9 @@ namespace FikaAmazonAPI.Services
 
         public async Task<List<MskuPrepDetail>> ListPrepDetailsAsync(ParameterListPrepDetails parameterListPrepDetails, CancellationToken cancellationToken = default)
         {
-            if (string.IsNullOrWhiteSpace(parameterListPrepDetails.marketplaceId))
+            if (string.IsNullOrWhiteSpace(parameterListPrepDetails.MarketplaceId))
             {
-                parameterListPrepDetails.marketplaceId = AmazonCredential.MarketPlace.ID;
+                parameterListPrepDetails.MarketplaceId = AmazonCredential.MarketPlace.ID;
             }
 
             var parameter = parameterListPrepDetails.getParameters();


### PR DESCRIPTION
Some methods hare having problems mapping the PaginationToken, making paginated calls to get into a cycle an retrieveing the max of 20 pages. If PaginationToken is renamed to paginationToken (cammel case) it works, so is a problem in the casing.
I have made a moregeneral fix, I restores the Pascal case names, and in the methos of creating the query parameters i convert ot cammel case

Related issues:

https://github.com/abuzuhri/Amazon-SP-API-CSharp/issues/786
https://github.com/abuzuhri/Amazon-SP-API-CSharp/issues/795