### PR TITLE
Create CamelCaseAttribute attribute for class and properties

### DIFF
--- a/Source/FikaAmazonAPI/Parameter/CamelCaseAttribute.cs
+++ b/Source/FikaAmazonAPI/Parameter/CamelCaseAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace FikaAmazonAPI.Parameter
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property)]
+    public class CamelCaseAttribute : Attribute
+    {
+    }
+
+}

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/ParameterGetLabels.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/ParameterGetLabels.cs
@@ -7,6 +7,8 @@ namespace FikaAmazonAPI.Parameter.FulFillmentInbound
     public class ParameterGetLabels : ParameterBased
     {
         public string MarketplaceId { get; set; }
+
+        [CamelCase]
         public string ShipmentId { get; set; }
         public PageType PageType { get; set; }
         public LabelType LabelType { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterConfirmPackingOption.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterConfirmPackingOption.cs
@@ -2,6 +2,7 @@
 
 namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterConfirmPackingOption : ParameterBased 
     {
         public string InboundPlanId { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListInboundPlanBase.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListInboundPlanBase.cs
@@ -1,5 +1,6 @@
 ﻿namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterListInboundPlanBase : PaginationParameter
     {
         public string InboundPlanId { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListInboundPlans.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListInboundPlans.cs
@@ -3,6 +3,7 @@ using FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320;
 
 namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterListInboundPlans : PaginationParameter
     {
         public string PaginationToken { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListPackingGroupBoxes.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListPackingGroupBoxes.cs
@@ -1,7 +1,8 @@
 ﻿namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterListPackingGroupBoxes : PaginationParameter
-    { 
+    {
         public string InboundPlanId { get; set; }
         public string PackingGroupId { get; set; }
         public string PaginationToken { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListPackingGroupItems.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListPackingGroupItems.cs
@@ -1,7 +1,8 @@
 ﻿namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterListPackingGroupItems : PaginationParameter
-    { 
+    {
         public string InboundPlanId { get; set; }
         public string PackingGroupId { get; set; }
         public string PaginationToken { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListPrepDetails.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListPrepDetails.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterListPrepDetails : ParameterBased
     {
         public string MarketplaceId { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListShipmentBase.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListShipmentBase.cs
@@ -1,7 +1,8 @@
 ﻿namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterListShipmentBase : PaginationParameter
-    { 
+    {
         public string InboundPlanId { get; set; }
         public string ShipmentId { get; set; }
         public string PaginationToken { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListTransportationOptions.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterListTransportationOptions.cs
@@ -1,5 +1,6 @@
 ﻿namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterListTransportationOptions : PaginationParameter
     {
         public string PlacementOptionId { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterUpdateItemComplianceDetails.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParameterUpdateItemComplianceDetails.cs
@@ -2,6 +2,7 @@
 
 namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParameterUpdateItemComplianceDetails : ParameterBased
     {
         public string MarketplaceId { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParematerListItemComplianceDetails.cs
+++ b/Source/FikaAmazonAPI/Parameter/FulFillmentInbound/v20240320/ParematerListItemComplianceDetails.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace FikaAmazonAPI.Parameter.FulFillmentInbound.v20240320
 {
+    [CamelCase]
     public class ParematerListItemComplianceDetails : ParameterBased
     {
         public ICollection<string> MSkus { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/ParameterBased.cs
+++ b/Source/FikaAmazonAPI/Parameter/ParameterBased.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Xml.Linq;
 
 namespace FikaAmazonAPI.Search
 {
@@ -21,6 +22,9 @@ namespace FikaAmazonAPI.Search
 
         public virtual List<KeyValuePair<string, string>> getParameters()
         {
+            // Check if the class is marked with the CamelCase attribute
+            var isClassCamelCase = Attribute.IsDefined(this.GetType(), typeof(CamelCaseAttribute));
+
             List<KeyValuePair<string, string>> queryParameters = new List<KeyValuePair<string, string>>();
             if (!string.IsNullOrEmpty(TestCase))
             {
@@ -76,8 +80,9 @@ namespace FikaAmazonAPI.Search
                         output = JsonConvert.SerializeObject(value, settings);
                     }
 
-                    // Convert to cammelCase to avoid issues with properties not being properly mapped
-                    var propName = char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1);
+                    // Check if property should be converted to cammel case
+                    var isPropertyCamelCase = isClassCamelCase || Attribute.IsDefined(p, typeof(CamelCaseAttribute));
+                    var propName = isPropertyCamelCase ? char.ToLowerInvariant(p.Name[0]) + p.Name.Substring(1) : p.Name;
 
                     queryParameters.Add(new KeyValuePair<string, string>(propName, output));
                 }


### PR DESCRIPTION
Fix for isssue: https://github.com/abuzuhri/Amazon-SP-API-CSharp/issues/804

This fix includes the creation of an attribute "CamelCaseAttribute" that can be applied to any parameter class or property, in that way we can customize the behaviour at class or property level. This is because New fulfillment uses  cammel case while other services like "OrderService" uses Pascal case, and even I saw a parameter class "ParameterGetLabels" that makes a combination of parameters in cammel (shipmentId)  and pascal case (all others) . With this Attribute we can cover all the  scenarios I think