### PR TITLE
Dynamic report encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ Please see [here](https://github.com/abuzuhri/Amazon-SP-API-CSharp/blob/main/Sou
 >>
 >> ***This is not required and will operate normally without the ProxyAddress being set.***
 
+
+### Configuration using Docker - Linux
+You need to add windows-1252 encoding
+```csharp
+    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+```
+ 
+
 ### Order List, For more orders sample please check [Here](https://github.com/abuzuhri/Amazon-SP-API-CSharp/blob/main/Source/FikaAmazonAPI.SampleCode/ReportsSample.cs).
 ```CSharp
 ParameterOrderList serachOrderList = new ParameterOrderList();

--- a/Source/FikaAmazonAPI/FikaAmazonAPI.csproj
+++ b/Source/FikaAmazonAPI/FikaAmazonAPI.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="Ude.NetStandard" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
         <None Include="..\..\Others\icon\icon.jpg">

--- a/Source/FikaAmazonAPI/ReportGeneration/ProductsReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ProductsReport.cs
@@ -7,12 +7,12 @@ namespace FikaAmazonAPI.ReportGeneration
     public class ProductsReport
     {
         public List<ProductsRow> Data { get; set; } = new List<ProductsRow>();
-        public ProductsReport(string path, Encoding encoding = default)
+        public ProductsReport(string path)
         {
             if (string.IsNullOrEmpty(path))
                 return;
 
-            var table = Table.ConvertFromCSV(path, encoding: encoding);
+            var table = Table.ConvertFromCSV(path);
 
             List<ProductsRow> values = new List<ProductsRow>();
             foreach (var row in table.Rows)

--- a/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace FikaAmazonAPI.ReportGeneration.ReportDataTable
 {
@@ -51,7 +52,7 @@ namespace FikaAmazonAPI.ReportGeneration.ReportDataTable
 
         public static Table ConvertFromCSV(string path, char separator = '\t')
         {
-            var lines = File.ReadAllLines(path, Encoding.UTF8);
+            var lines = File.ReadAllLines(path, EncodingHelper.GetEncodingFromCulture(Thread.CurrentThread.CurrentCulture));
 
             var table = new Table(lines.First().Split(separator));
 

--- a/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using FikaAmazonAPI.Utils;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -48,12 +49,11 @@ namespace FikaAmazonAPI.ReportGeneration.ReportDataTable
             this.header = header;
         }
 
-        public static Table ConvertFromCSV(string path, char separator = '\t', Encoding encoding = default)
+        public static Table ConvertFromCSV(string path, char separator = '\t')
         {
-            var lines = File.ReadAllLines(path, encoding ?? Encoding.UTF8);
+            var lines = File.ReadAllLines(path, Encoding.UTF8);
 
             var table = new Table(lines.First().Split(separator));
-
 
             lines.Skip(1).ToList().ForEach(a => ConvertFromCSVAddRow(table, a, separator));
             return table;

--- a/Source/FikaAmazonAPI/Services/ReportService.cs
+++ b/Source/FikaAmazonAPI/Services/ReportService.cs
@@ -247,6 +247,8 @@ namespace FikaAmazonAPI.Services
 
                 cancellationToken.ThrowIfCancellationRequested();
 
+                FileTransform.ConvertFileToUtf8(tempFilePath);
+
                 return tempFilePath;
             }
             catch (OperationCanceledException)

--- a/Source/FikaAmazonAPI/Services/ReportService.cs
+++ b/Source/FikaAmazonAPI/Services/ReportService.cs
@@ -247,7 +247,7 @@ namespace FikaAmazonAPI.Services
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                FileTransform.ConvertFileToUtf8(tempFilePath);
+                FileTransform.SetFileEncoding(tempFilePath);
 
                 return tempFilePath;
             }

--- a/Source/FikaAmazonAPI/Utils/EncodingHelper.cs
+++ b/Source/FikaAmazonAPI/Utils/EncodingHelper.cs
@@ -1,0 +1,26 @@
+﻿using System.Globalization;
+using System.Text;
+
+namespace FikaAmazonAPI.Utils
+{
+    public static class EncodingHelper
+    {
+        public static Encoding GetEncodingFromCulture(CultureInfo culture)
+        {
+            string cultureName = culture.Name.ToLower();
+
+            return cultureName switch
+            {
+                "en-us" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
+                "de-de" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
+                "fr-fr" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
+                "ja-jp" => Encoding.GetEncoding("shift_jis"), // Japanisch
+                "zh-cn" => Encoding.GetEncoding("gb2312"), // Vereinfachtes Chinesisch
+                "ru-ru" => Encoding.GetEncoding("Windows-1251"), // Kyrillisch
+                "ko-kr" => Encoding.GetEncoding("ks_c_5601-1987"), // Koreanisch
+                "ar-sa" => Encoding.GetEncoding("Windows-1256"), // Arabisch
+                _ => Encoding.UTF8 // Standard als Fallback
+            };
+        }
+    }
+}

--- a/Source/FikaAmazonAPI/Utils/FileTransform.cs
+++ b/Source/FikaAmazonAPI/Utils/FileTransform.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using Ude;
 
 namespace FikaAmazonAPI.Utils
 {
@@ -31,8 +35,6 @@ namespace FikaAmazonAPI.Utils
 
         }
 
-
-
         public static string Decompress(string fileName)
         {
             FileInfo fileInfo = new FileInfo(fileName);
@@ -54,6 +56,39 @@ namespace FikaAmazonAPI.Utils
             }
         }
 
+        public static void ConvertFileToUtf8(string filePath)
+        {
+            string content = File.ReadAllText(filePath, DetectFileEncoding(filePath));
+            File.WriteAllText(filePath, content, GetEncodingFromCulture(Thread.CurrentThread.CurrentCulture));
+        }
+        static Encoding DetectFileEncoding(string filePath)
+        {
+            using (FileStream fs = File.OpenRead(filePath))
+            {
+                CharsetDetector detector = new CharsetDetector();
+                detector.Feed(fs);
+                detector.DataEnd();
 
+                return detector.Charset != null ? Encoding.GetEncoding(detector.Charset) : Encoding.UTF8;
+            }
+        }
+
+        static Encoding GetEncodingFromCulture(CultureInfo culture)
+        {
+            string cultureName = culture.Name.ToLower();
+
+            return cultureName switch
+            {
+                "en-us" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
+                "de-de" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
+                "fr-fr" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
+                "ja-jp" => Encoding.GetEncoding("shift_jis"), // Japanisch
+                "zh-cn" => Encoding.GetEncoding("gb2312"), // Vereinfachtes Chinesisch
+                "ru-ru" => Encoding.GetEncoding("Windows-1251"), // Kyrillisch
+                "ko-kr" => Encoding.GetEncoding("ks_c_5601-1987"), // Koreanisch
+                "ar-sa" => Encoding.GetEncoding("Windows-1256"), // Arabisch
+                _ => Encoding.UTF8 // Standard als Fallback
+            };
+        }
     }
 }

--- a/Source/FikaAmazonAPI/Utils/FileTransform.cs
+++ b/Source/FikaAmazonAPI/Utils/FileTransform.cs
@@ -56,11 +56,12 @@ namespace FikaAmazonAPI.Utils
             }
         }
 
-        public static void ConvertFileToUtf8(string filePath)
+        public static void SetFileEncoding(string filePath)
         {
             string content = File.ReadAllText(filePath, DetectFileEncoding(filePath));
-            File.WriteAllText(filePath, content, GetEncodingFromCulture(Thread.CurrentThread.CurrentCulture));
+            File.WriteAllText(filePath, content, EncodingHelper.GetEncodingFromCulture(Thread.CurrentThread.CurrentCulture));
         }
+
         static Encoding DetectFileEncoding(string filePath)
         {
             using (FileStream fs = File.OpenRead(filePath))
@@ -73,22 +74,5 @@ namespace FikaAmazonAPI.Utils
             }
         }
 
-        static Encoding GetEncodingFromCulture(CultureInfo culture)
-        {
-            string cultureName = culture.Name.ToLower();
-
-            return cultureName switch
-            {
-                "en-us" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
-                "de-de" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
-                "fr-fr" => Encoding.GetEncoding("Windows-1252"), // Westeuropa (ANSI)
-                "ja-jp" => Encoding.GetEncoding("shift_jis"), // Japanisch
-                "zh-cn" => Encoding.GetEncoding("gb2312"), // Vereinfachtes Chinesisch
-                "ru-ru" => Encoding.GetEncoding("Windows-1251"), // Kyrillisch
-                "ko-kr" => Encoding.GetEncoding("ks_c_5601-1987"), // Koreanisch
-                "ar-sa" => Encoding.GetEncoding("Windows-1256"), // Arabisch
-                _ => Encoding.UTF8 // Standard als Fallback
-            };
-        }
     }
 }


### PR DESCRIPTION
Added support for dynamic report encoding. 

1. Read the file using the correct encoding -> ReportService.cs
2. Save the file with the target encoding, determined by Thread.CurrentThread.CurrentCulture on AmazonConnection -> FileTransform.cs
3. Read the file again to extract report values with the correct encoding ->Tables.cs