### PR TITLE
Removing call that was added that created a bug that will not allow PII data.

### DIFF
--- a/Source/FikaAmazonAPI/Services/RequestService.cs
+++ b/Source/FikaAmazonAPI/Services/RequestService.cs
@@ -123,7 +123,6 @@ namespace FikaAmazonAPI.Services
             CancellationToken cancellationToken = default) where T : new()
         {
             RestHeader();
-            await RefreshToken();
             AddAccessToken();
             AddShippingBusinessId();
 


### PR DESCRIPTION
Removing the code was is causing the Restricted Data Token To be set back to the normal token. This is causing the orders to not return restricted data.