### PR TITLE
Allow passing query parameters to `ListFinancialEventsByGroupId`

### DIFF
--- a/Source/FikaAmazonAPI.SampleCode/FinancialSample.cs
+++ b/Source/FikaAmazonAPI.SampleCode/FinancialSample.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using FikaAmazonAPI.AmazonSpApiSDK.Models.Finances;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,15 +15,27 @@ namespace FikaAmazonAPI.SampleCode
             this.amazonConnection = amazonConnection;
         }
 
-        public void ListFinancialEventGroups()
+        public IList<FinancialEventGroup> ListFinancialEventGroups()
         {
-            amazonConnection.Financial.ListFinancialEventGroups(new Parameter.Finance.ParameterListFinancialEventGroup()
+            return amazonConnection.Financial.ListFinancialEventGroups(new Parameter.Finance.ParameterListFinancialEventGroup()
             {
                 FinancialEventGroupStartedAfter = DateTime.UtcNow.AddDays(-10),
                 FinancialEventGroupStartedBefore = DateTime.UtcNow.AddDays(-1),
                 MaxResultsPerPage = 55
             });
+        }
 
+        public List<FinancialEvents> ListFinancialEventsByGroupId(string financialGroupId)
+        {
+            var financialEventsWithoutParams = amazonConnection.Financial.ListFinancialEventsByGroupId(financialGroupId);
+            var financialEventsWithParams = amazonConnection.Financial.ListFinancialEventsByGroupId(financialGroupId,
+                new Parameter.Finance.ParameterListFinancialEventsByGroupId()
+                {
+                    PostedAfter = DateTime.UtcNow.AddDays(-170),
+                    PostedBefore = DateTime.UtcNow.AddMinutes(-60),
+                    MaxResultsPerPage = 55
+                });
+            return financialEventsWithParams;
         }
     }
 }

--- a/Source/FikaAmazonAPI/Parameter/Finance/ParameterListFinancialEventsByGroupId.cs
+++ b/Source/FikaAmazonAPI/Parameter/Finance/ParameterListFinancialEventsByGroupId.cs
@@ -1,0 +1,13 @@
+﻿using FikaAmazonAPI.Search;
+using System;
+
+namespace FikaAmazonAPI.Parameter.Finance
+{
+    public class ParameterListFinancialEventsByGroupId : ParameterBased
+    {
+        public int? MaxResultsPerPage { get; set; } = 100;
+        public DateTime? PostedAfter { get; set; }
+        public DateTime? PostedBefore { get; set; }
+        public string NextToken { get; set; }
+    }
+}

--- a/Source/FikaAmazonAPI/Services/FinancialService.cs
+++ b/Source/FikaAmazonAPI/Services/FinancialService.cs
@@ -55,11 +55,13 @@ namespace FikaAmazonAPI.Services
         }
 
 
-        public List<FinancialEvents> ListFinancialEventsByGroupId(string eventGroupId) =>
-                Task.Run(() => ListFinancialEventsByGroupIdAsync(eventGroupId)).ConfigureAwait(false).GetAwaiter().GetResult();
-        public async Task<List<FinancialEvents>> ListFinancialEventsByGroupIdAsync(string eventGroupId, CancellationToken cancellationToken = default)
+        public List<FinancialEvents> ListFinancialEventsByGroupId(string eventGroupId, ParameterListFinancialEventsByGroupId parameterListFinancialEventsByGroupId = null) =>
+                Task.Run(() => ListFinancialEventsByGroupIdAsync(eventGroupId, parameterListFinancialEventsByGroupId)).ConfigureAwait(false).GetAwaiter().GetResult();
+        public async Task<List<FinancialEvents>> ListFinancialEventsByGroupIdAsync(string eventGroupId, ParameterListFinancialEventsByGroupId parameterListFinancialEventsByGroupId = null, 
+            CancellationToken cancellationToken = default)
         {
-            await CreateAuthorizedRequestAsync(FinanceApiUrls.ListFinancialEventsByGroupId(eventGroupId), RestSharp.Method.Get, cancellationToken: cancellationToken);
+            var parameters = parameterListFinancialEventsByGroupId?.getParameters() ?? new List<KeyValuePair<string, string>>();
+            await CreateAuthorizedRequestAsync(FinanceApiUrls.ListFinancialEventsByGroupId(eventGroupId), RestSharp.Method.Get, queryParameters: parameters, cancellationToken: cancellationToken);
             var response = await ExecuteRequestAsync<ListFinancialEventsResponse>(RateLimitType.Financial_ListFinancialEventsByGroupId, cancellationToken);
 
             var nextToken = response.Payload.NextToken;


### PR DESCRIPTION
This PR adds the ability to pass optional query parameters to the `ListFinancialEventsByGroupId()` function.
This fixes #865.

I tried to follow the existing patterns for optional query parameters by looking at the implementation of `ListFinancialEventGroups`, which already allows the passing of query parameters.

The implemtentation also aims at not breaking existing code by making the new argument optional.

Side note:
While I included `NextToken` in the parameter class, creating a method for actually fetching the next page of a `ListFinancialEventsByGroupId` query is explicitly out of scope for this PR.