### PR TITLE
Fix patch HTTP method for netstandard2.0

### DIFF
--- a/Source/RestSharp/RestClient.cs
+++ b/Source/RestSharp/RestClient.cs
@@ -14,6 +14,7 @@ namespace RestSharp
     {
         public RestClientOptions Options { get; }
         private readonly HttpClient _httpClient;
+        private static readonly HttpMethod PatchMethod = new HttpMethod("PATCH");
 
         public RestClient(RestClientOptions options, Action<RestClient> configureSerialization = null)
         {
@@ -45,7 +46,7 @@ namespace RestSharp
                 Method.Post => HttpMethod.Post,
                 Method.Put => HttpMethod.Put,
                 Method.Delete => HttpMethod.Delete,
-                Method.Patch => HttpMethod.Patch,
+                Method.Patch => PatchMethod,
                 _ => HttpMethod.Get
             };
         }


### PR DESCRIPTION
## Summary
- define a `PATCH` method for RestClient when running on netstandard2.0

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d55536408322a81b0a25c719d085