### PR TITLE
Fix LWAClient error handling for simplified RestSharp

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Runtime/LWAClient.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Runtime/LWAClient.cs
@@ -65,7 +65,10 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Runtime
 
                 if (!IsSuccessful(response))
                 {
-                    throw new IOException("Unsuccessful LWA token exchange", response.ErrorException);
+                    var message = string.IsNullOrEmpty(response.ErrorMessage)
+                        ? "Unsuccessful LWA token exchange"
+                        : $"Unsuccessful LWA token exchange: {response.ErrorMessage}";
+                    throw new IOException(message);
                 }
 
                 var tokenResponse = JsonConvert.DeserializeObject<TokenResponse>(response.Content);


### PR DESCRIPTION
## Summary
- handle RestResponse error messages in LWAClient without using missing `ErrorException` property

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6864d55d427083228c8b20f2f2a9d881