### PR TITLE
Add MemoryStream version for report download

### DIFF
--- a/Source/FikaAmazonAPI/Utils/FileTransform.cs
+++ b/Source/FikaAmazonAPI/Utils/FileTransform.cs
@@ -54,6 +54,24 @@ namespace FikaAmazonAPI.Utils
             }
         }
 
+        public static MemoryStream Decompress(Stream compressedStream)
+        {
+            if (compressedStream == null)
+                throw new ArgumentNullException(nameof(compressedStream));
+
+            if (compressedStream.CanSeek)
+                compressedStream.Position = 0;
+
+            var outputStream = new MemoryStream();
+            using (var decompressionStream = new GZipStream(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+            {
+                decompressionStream.CopyTo(outputStream);
+            }
+            if (outputStream.CanSeek)
+                outputStream.Position = 0;
+            return outputStream;
+        }
+
 
     }
 }


### PR DESCRIPTION
## Summary
- add `Decompress(Stream)` helper to `FileTransform`
- implement MemoryStream retrieval in `ReportService`
- expose `CreateReportAndDownloadFileStream*` and `GetReportFileStream*` methods

## Testing
- `dotnet test --no-build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686540056ce483229881a131b1841a4c