### PR TITLE
Fix Requirements enum for product type parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ var def = amazonConnection.ProductType.GetDefinitionsProductType(
    new Parameter.ProductTypes.GetDefinitionsProductTypeParameter()
     {
      productType = "PRODUCT",
-     requirements = RequirementsEnum.LISTING,
+     requirements = Requirements.LISTING,
      locale = AmazonSpApiSDK.Models.ProductTypes.LocaleEnum.en_US
      });
 ```

--- a/Source/FikaAmazonAPI.SampleCode/ProductTypeSample.cs
+++ b/Source/FikaAmazonAPI.SampleCode/ProductTypeSample.cs
@@ -1,4 +1,4 @@
-﻿using static FikaAmazonAPI.AmazonSpApiSDK.Models.ListingsItems.ListingsItemPutRequest;
+﻿using FikaAmazonAPI.Parameter.ListingItem;
 
 namespace FikaAmazonAPI.SampleCode
 {
@@ -27,7 +27,7 @@ namespace FikaAmazonAPI.SampleCode
                 new Parameter.ProductTypes.GetDefinitionsProductTypeParameter()
                 {
                     productType = "PRODUCT",
-                    requirements = RequirementsEnum.LISTING,
+                    requirements = Requirements.LISTING,
                     locale = AmazonSpApiSDK.Models.ProductTypes.LocaleEnum.en_US
                 });
         }

--- a/Source/FikaAmazonAPI/Parameter/ProductTypes/GetDefinitionsProductTypeParameter.cs
+++ b/Source/FikaAmazonAPI/Parameter/ProductTypes/GetDefinitionsProductTypeParameter.cs
@@ -1,7 +1,7 @@
 ﻿using FikaAmazonAPI.AmazonSpApiSDK.Models.ProductTypes;
 using FikaAmazonAPI.Search;
 using System.Collections.Generic;
-using static FikaAmazonAPI.AmazonSpApiSDK.Models.ListingsItems.ListingsItemPutRequest;
+using FikaAmazonAPI.Parameter.ListingItem;
 
 namespace FikaAmazonAPI.Parameter.ProductTypes
 {
@@ -12,7 +12,7 @@ namespace FikaAmazonAPI.Parameter.ProductTypes
         public string sellerId { get; set; }
         public ICollection<string> marketplaceIds { get; set; } = new List<string>();
         public string productTypeVersion { get; set; }
-        public RequirementsEnum? requirements { get; set; }
+        public Requirements? requirements { get; set; }
         public RequirementsEnforcedEnum? requirementsEnforced { get; set; }
         public LocaleEnum? locale { get; set; }
 


### PR DESCRIPTION
## Summary
- use `Requirements` enum in `GetDefinitionsProductTypeParameter`
- update sample code to match new enum
- fix README example

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867943ac11083229933adc4ec8dfd2f