### PR TITLE
Add generic parser for report streams

### DIFF
--- a/Source/FikaAmazonAPI/ReportGeneration/CategoriesReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/CategoriesReport.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml.Serialization;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -22,6 +23,24 @@ namespace FikaAmazonAPI.ReportGeneration
                 {
                     Data = (CategoriesData)serializer.Deserialize(reader);
                 }
+            }
+            catch (System.Exception e)
+            {
+                throw e;
+            }
+        }
+
+        public CategoriesReport(Stream stream, string refNumber)
+        {
+            if (stream == null || stream.Length == 0)
+                return;
+
+            stream.Position = 0;
+            var serializer = new XmlSerializer(typeof(CategoriesData));
+
+            try
+            {
+                Data = (CategoriesData)serializer.Deserialize(stream);
             }
             catch (System.Exception e)
             {

--- a/Source/FikaAmazonAPI/ReportGeneration/FbaEstimateFeeReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/FbaEstimateFeeReport.cs
@@ -1,6 +1,8 @@
 ﻿using FikaAmazonAPI.ReportGeneration.ReportDataTable;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -20,6 +22,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(FbaEstimateFeeReportRow.FromRow(row, refNumber));
             }
             Data = values;
+        }
+
+        public FbaEstimateFeeReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseTableRows(stream, FbaEstimateFeeReportRow.FromRow, refNumber);
         }
     }
     public class FbaEstimateFeeReportRow

--- a/Source/FikaAmazonAPI/ReportGeneration/FeedbackOrderReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/FeedbackOrderReport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -17,6 +18,11 @@ namespace FikaAmazonAPI.ReportGeneration
                                            .Select(v => FeedbackOrderRow.FromCsv(v, refNumber))
                                            .ToList();
             Data = values;
+        }
+
+        public FeedbackOrderReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseCsvLines(stream, FeedbackOrderRow.FromCsv, refNumber);
         }
 
 

--- a/Source/FikaAmazonAPI/ReportGeneration/InventoryAgingReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/InventoryAgingReport.cs
@@ -1,6 +1,8 @@
-﻿using FikaAmazonAPI.ReportGeneration.ReportDataTable;
+using FikaAmazonAPI.ReportGeneration.ReportDataTable;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -20,6 +22,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(InventoryAgingRow.FromRow(row, refNumber));
             }
             Data = values;
+        }
+
+        public InventoryAgingReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseTableRows(stream, InventoryAgingRow.FromRow, refNumber);
         }
     }
     public class InventoryAgingRow

--- a/Source/FikaAmazonAPI/ReportGeneration/InventoryPlanningDataReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/InventoryPlanningDataReport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using FikaAmazonAPI.ReportGeneration.ReportDataTable;
+using System.IO;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -21,6 +22,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(InventoryPlanningDataRow.FromRow(row, refNumber));
             }
             Data = values;
+        }
+
+        public InventoryPlanningDataReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseTableRows(stream, InventoryPlanningDataRow.FromRow, refNumber);
         }
     }
 

--- a/Source/FikaAmazonAPI/ReportGeneration/LedgerDetailReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/LedgerDetailReport.cs
@@ -1,6 +1,8 @@
-﻿using FikaAmazonAPI.ReportGeneration.ReportDataTable;
+using FikaAmazonAPI.ReportGeneration.ReportDataTable;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -20,6 +22,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(LedgerDetailReportRow.FromRow(row, refNumber));
             }
             Data = values;
+        }
+
+        public LedgerDetailReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseTableRows(stream, LedgerDetailReportRow.FromRow, refNumber);
         }
     }
     public class LedgerDetailReportRow

--- a/Source/FikaAmazonAPI/ReportGeneration/OrderInvoicingReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/OrderInvoicingReport.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -22,6 +23,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(OrderInvoicingReportRow.FromRow(row, refNumber));
             }
             Data = values;
+        }
+
+        public OrderInvoicingReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseTableRows(stream, OrderInvoicingReportRow.FromRow, refNumber);
         }
     }
 

--- a/Source/FikaAmazonAPI/ReportGeneration/OrdersReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/OrdersReport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -17,6 +18,11 @@ namespace FikaAmazonAPI.ReportGeneration
                                            .Select(v => OrdersRow.FromCsv(v, refNumber))
                                            .ToList();
             Data = values;
+        }
+
+        public OrdersReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseCsvLines(stream, OrdersRow.FromCsv, refNumber);
         }
 
 

--- a/Source/FikaAmazonAPI/ReportGeneration/ProductAFNInventoryReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ProductAFNInventoryReport.cs
@@ -19,6 +19,11 @@ namespace FikaAmazonAPI.ReportGeneration
                                            .ToList();
             Data = values;
         }
+
+        public ProductAFNInventoryReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseCsvLines(stream, ProductAFNInventoryRow.FromCsv, refNumber);
+        }
     }
 
     public class ProductAFNInventoryRow

--- a/Source/FikaAmazonAPI/ReportGeneration/ProductsReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ProductsReport.cs
@@ -1,6 +1,7 @@
-﻿using FikaAmazonAPI.ReportGeneration.ReportDataTable;
+using FikaAmazonAPI.ReportGeneration.ReportDataTable;
 using System.Collections.Generic;
 using System.Text;
+using System.IO;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -20,6 +21,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(ProductsRow.FromRow(row));
             }
             Data = values;
+        }
+
+        public ProductsReport(Stream stream, Encoding encoding = default)
+        {
+            Data = ReportParser.ParseTableRows(stream, ProductsRow.FromRow, encoding: encoding);
         }
 
 

--- a/Source/FikaAmazonAPI/ReportGeneration/ReferralFeeReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReferralFeeReport.cs
@@ -1,6 +1,8 @@
-﻿using FikaAmazonAPI.ReportGeneration.ReportDataTable;
+using FikaAmazonAPI.ReportGeneration.ReportDataTable;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -20,6 +22,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(ReferralFeeReportRow.FromRow(row, refNumber));
             }
             Data = values;
+        }
+
+        public ReferralFeeReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseTableRows(stream, ReferralFeeReportRow.FromRow, refNumber);
         }
     }
     public class ReferralFeeReportRow

--- a/Source/FikaAmazonAPI/ReportGeneration/ReimbursementsOrderReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReimbursementsOrderReport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -17,6 +18,11 @@ namespace FikaAmazonAPI.ReportGeneration
                                            .Select(v => ReimbursementsOrderRow.FromCsv(v, refNumber))
                                            .ToList();
             Data = values;
+        }
+
+        public ReimbursementsOrderReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseCsvLines(stream, ReimbursementsOrderRow.FromCsv, refNumber);
         }
 
 

--- a/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
@@ -58,6 +58,21 @@ namespace FikaAmazonAPI.ReportGeneration.ReportDataTable
             lines.Skip(1).ToList().ForEach(a => ConvertFromCSVAddRow(table, a, separator));
             return table;
         }
+
+        public static Table ConvertFromCSV(Stream stream, char separator = '\t', Encoding encoding = default)
+        {
+            using var reader = new StreamReader(stream, encoding ?? Encoding.UTF8, leaveOpen: true);
+            var lines = new List<string>();
+            while (!reader.EndOfStream)
+                lines.Add(reader.ReadLine());
+
+            if (lines.Count == 0)
+                return null;
+
+            var table = new Table(lines.First().Split(separator));
+            lines.Skip(1).ToList().ForEach(a => ConvertFromCSVAddRow(table, a, separator));
+            return table;
+        }
         private static void ConvertFromCSVAddRow(Table table, string line, char separator)
         {
             table.AddRow(line.Split(separator));

--- a/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportDataTable/Table.cs
@@ -61,7 +61,8 @@ namespace FikaAmazonAPI.ReportGeneration.ReportDataTable
 
         public static Table ConvertFromCSV(Stream stream, char separator = '\t', Encoding encoding = default)
         {
-            using var reader = new StreamReader(stream, encoding ?? Encoding.UTF8, leaveOpen: true);
+            using var reader = new StreamReader(stream, encoding ?? Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
             var lines = new List<string>();
             while (!reader.EndOfStream)
                 lines.Add(reader.ReadLine());

--- a/Source/FikaAmazonAPI/ReportGeneration/ReportManager.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportManager.cs
@@ -3,6 +3,7 @@ using FikaAmazonAPI.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using static FikaAmazonAPI.Utils.Constants;
@@ -35,15 +36,15 @@ namespace FikaAmazonAPI.ReportGeneration
 
         public async Task<List<FeedbackOrderRow>> GetFeedbackFromDateAsync(DateTime fromDate, DateTime toDate)
         {
-            var path = await GetFeedbackFromDateAsync(_amazonConnection, fromDate, toDate);
-            FeedbackOrderReport report = new FeedbackOrderReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetFeedbackFromDateAsync(_amazonConnection, fromDate, toDate);
+            FeedbackOrderReport report = new FeedbackOrderReport(stream, _amazonConnection.RefNumber);
             return report.Data;
         }
 
-        private async Task<string> GetFeedbackFromDateAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetFeedbackFromDateAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes.GET_SELLER_FEEDBACK_DATA,
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(ReportTypes.GET_SELLER_FEEDBACK_DATA,
                 fromDate);
         }
 
@@ -71,15 +72,15 @@ namespace FikaAmazonAPI.ReportGeneration
 
         public async Task<IList<ReimbursementsOrderRow>> GetReimbursementsOrderAsync(DateTime fromDate, DateTime toDate)
         {
-            var path = await GetReimbursementsOrderAsync(_amazonConnection, fromDate, toDate);
-            ReimbursementsOrderReport report = new ReimbursementsOrderReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetReimbursementsOrderAsync(_amazonConnection, fromDate, toDate);
+            ReimbursementsOrderReport report = new ReimbursementsOrderReport(stream, _amazonConnection.RefNumber);
             return report.Data;
         }
 
-        private async Task<string> GetReimbursementsOrderAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetReimbursementsOrderAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_FBA_REIMBURSEMENTS_DATA, fromDate, toDate);
         }
 
@@ -106,17 +107,17 @@ namespace FikaAmazonAPI.ReportGeneration
         public async Task<List<ReturnFBAOrderRow>> GetReturnFBAOrderAsync(DateTime fromDate, DateTime toDate,
             List<MarketPlace> marketplaces = null, CancellationToken cancellationToken = default)
         {
-            var path = await GetReturnFBAOrderAsync(_amazonConnection, fromDate, toDate, marketplaces,
+            using var stream = await GetReturnFBAOrderAsync(_amazonConnection, fromDate, toDate, marketplaces,
                 cancellationToken);
-            ReturnFBAOrderReport report = new ReturnFBAOrderReport(path, _amazonConnection.RefNumber);
+            ReturnFBAOrderReport report = new ReturnFBAOrderReport(stream, _amazonConnection.RefNumber);
 
             return report.Data;
         }
 
-        private async Task<string> GetReturnFBAOrderAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetReturnFBAOrderAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate, List<MarketPlace> marketplaces = null, CancellationToken cancellationToken = default)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_FBA_FULFILLMENT_CUSTOMER_RETURNS_DATA, fromDate, toDate, marketplaces: marketplaces,
                 cancellationToken: cancellationToken);
         }
@@ -144,19 +145,18 @@ namespace FikaAmazonAPI.ReportGeneration
             var dateList = ReportDateRange.GetDateRange(fromDate, toDate, DAY_60);
             foreach (var date in dateList)
             {
-                var path = await GetReturnMFNOrderAsync(_amazonConnection, date.StartDate, date.EndDate);
-
-                ReturnFBMOrderReport report = new ReturnFBMOrderReport(path, _amazonConnection.RefNumber);
+                using var stream = await GetReturnMFNOrderAsync(_amazonConnection, date.StartDate, date.EndDate);
+                ReturnFBMOrderReport report = new ReturnFBMOrderReport(stream, _amazonConnection.RefNumber);
                 list.AddRange(report.Data);
             }
 
             return list;
         }
 
-        private async Task<string> GetReturnMFNOrderAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetReturnMFNOrderAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_FLAT_FILE_RETURNS_DATA_BY_RETURN_DATE, fromDate, toDate);
         }
 
@@ -181,20 +181,21 @@ namespace FikaAmazonAPI.ReportGeneration
             if (totalDays > 90)
                 fromDate = DateTime.UtcNow.AddDays(-90);
 
-            var paths = await GetSettlementOrderAsync(_amazonConnection, fromDate, toDate);
-            foreach (var path in paths)
+            var streams = await GetSettlementOrderAsync(_amazonConnection, fromDate, toDate);
+            foreach (var stream in streams)
             {
-                SettlementOrderReport report = new SettlementOrderReport(path, _amazonConnection.RefNumber);
+                using var s = stream;
+                SettlementOrderReport report = new SettlementOrderReport(s, _amazonConnection.RefNumber);
                 list.AddRange(report.Data);
             }
 
             return list;
         }
 
-        private async Task<IList<string>> GetSettlementOrderAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<IList<MemoryStream>> GetSettlementOrderAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
-            return await amazonConnection.Reports.DownloadExistingReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.DownloadExistingReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE_V2, fromDate, toDate);
         }
 
@@ -205,14 +206,14 @@ namespace FikaAmazonAPI.ReportGeneration
 
         public async Task<List<UnsuppressedInventoryDataRow>> GetUnsuppressedInventoryDataAsync()
         {
-            var path = await GetUnsuppressedInventoryDatayAsync(_amazonConnection);
-            var report = new UnsuppressedInventoryDataReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetUnsuppressedInventoryDatayAsync(_amazonConnection);
+            var report = new UnsuppressedInventoryDataReport(stream, _amazonConnection.RefNumber);
             return report.Data;
         }
 
-        private async Task<string> GetUnsuppressedInventoryDatayAsync(AmazonConnection amazonConnection)
+        private async Task<MemoryStream> GetUnsuppressedInventoryDatayAsync(AmazonConnection amazonConnection)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(ReportTypes
                 .GET_FBA_MYI_UNSUPPRESSED_INVENTORY_DATA);
         }
 
@@ -222,14 +223,14 @@ namespace FikaAmazonAPI.ReportGeneration
 
         public async Task<List<ProductAFNInventoryRow>> GetAFNInventoryQtyAsync()
         {
-            var path = await GetAFNInventoryQtyAsync(_amazonConnection);
-            ProductAFNInventoryReport report = new ProductAFNInventoryReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetAFNInventoryQtyAsync(_amazonConnection);
+            ProductAFNInventoryReport report = new ProductAFNInventoryReport(stream, _amazonConnection.RefNumber);
             return report.Data;
         }
 
-        private async Task<string> GetAFNInventoryQtyAsync(AmazonConnection amazonConnection)
+        private async Task<MemoryStream> GetAFNInventoryQtyAsync(AmazonConnection amazonConnection)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes.GET_AFN_INVENTORY_DATA);
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(ReportTypes.GET_AFN_INVENTORY_DATA);
         }
 
         #endregion
@@ -241,14 +242,14 @@ namespace FikaAmazonAPI.ReportGeneration
 
         public async Task<List<InventoryAgingRow>> GetInventoryAgingAsync()
         {
-            var path = await GetInventoryAgingAsync(_amazonConnection);
-            InventoryAgingReport report = new InventoryAgingReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetInventoryAgingAsync(_amazonConnection);
+            InventoryAgingReport report = new InventoryAgingReport(stream, _amazonConnection.RefNumber);
             return report.Data;
         }
 
-        private async Task<string> GetInventoryAgingAsync(AmazonConnection amazonConnection)
+        private async Task<MemoryStream> GetInventoryAgingAsync(AmazonConnection amazonConnection)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(ReportTypes
                 .GET_FBA_INVENTORY_AGED_DATA);
         }
 
@@ -262,15 +263,15 @@ namespace FikaAmazonAPI.ReportGeneration
         public async Task<List<ProductsRow>> GetProductsAsync(List<MarketPlace> marketplaces = null,
             CancellationToken cancellationToken = default)
         {
-            var path = await GetProductsAsync(_amazonConnection, marketplaces, cancellationToken);
-            ProductsReport report = new ProductsReport(path);
+            using var stream = await GetProductsAsync(_amazonConnection, marketplaces, cancellationToken);
+            ProductsReport report = new ProductsReport(stream);
             return report.Data;
         }
 
-        private Task<string> GetProductsAsync(AmazonConnection amazonConnection, List<MarketPlace> marketplaces = null,
+        private Task<MemoryStream> GetProductsAsync(AmazonConnection amazonConnection, List<MarketPlace> marketplaces = null,
             CancellationToken cancellationToken = default)
         {
-            return amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes.GET_MERCHANT_LISTINGS_ALL_DATA,
+            return amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(ReportTypes.GET_MERCHANT_LISTINGS_ALL_DATA,
                 marketplaces: marketplaces, cancellationToken: cancellationToken);
         }
 
@@ -285,14 +286,14 @@ namespace FikaAmazonAPI.ReportGeneration
 
         public async Task<List<CategoriesRow>> GetCategoriesAsync(bool rootNodesOnly = false)
         {
-            var path = await GetCategoriesAsync(_amazonConnection, rootNodesOnly);
-            CategoriesReport report = new CategoriesReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetCategoriesAsync(_amazonConnection, rootNodesOnly);
+            CategoriesReport report = new CategoriesReport(stream, _amazonConnection.RefNumber);
             return report.Data.Node;
         }
 
-        private async Task<string> GetCategoriesAsync(AmazonConnection amazonConnection, bool rootNodesOnly)
+        private async Task<MemoryStream> GetCategoriesAsync(AmazonConnection amazonConnection, bool rootNodesOnly)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes.GET_XML_BROWSE_TREE_DATA,
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(ReportTypes.GET_XML_BROWSE_TREE_DATA,
                 reportOptions: new ReportOptions
                 {
                     { "RootNodesOnly", rootNodesOnly.ToString() }
@@ -319,18 +320,18 @@ namespace FikaAmazonAPI.ReportGeneration
             var dateList = ReportDateRange.GetDateRange(fromDate, toDate, DAY_30);
             foreach (var range in dateList)
             {
-                var path = await GetOrdersByLastUpdateAsync(_amazonConnection, range.StartDate, range.EndDate);
-                OrdersReport report = new OrdersReport(path, _amazonConnection.RefNumber);
+                using var stream = await GetOrdersByLastUpdateAsync(_amazonConnection, range.StartDate, range.EndDate);
+                OrdersReport report = new OrdersReport(stream, _amazonConnection.RefNumber);
                 list.AddRange(report.Data);
             }
 
             return list;
         }
 
-        private async Task<string> GetOrdersByLastUpdateAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetOrdersByLastUpdateAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_FLAT_FILE_ALL_ORDERS_DATA_BY_LAST_UPDATE_GENERAL, fromDate, toDate);
         }
 
@@ -353,18 +354,18 @@ namespace FikaAmazonAPI.ReportGeneration
             var dateList = ReportDateRange.GetDateRange(fromDate, toDate, DAY_30);
             foreach (var range in dateList)
             {
-                var path = await GetOrdersByOrderDateAsync(_amazonConnection, range.StartDate, range.EndDate);
-                OrdersReport report = new OrdersReport(path, _amazonConnection.RefNumber);
+                using var stream = await GetOrdersByOrderDateAsync(_amazonConnection, range.StartDate, range.EndDate);
+                OrdersReport report = new OrdersReport(stream, _amazonConnection.RefNumber);
                 list.AddRange(report.Data);
             }
 
             return list;
         }
 
-        private async Task<string> GetOrdersByOrderDateAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetOrdersByOrderDateAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_FLAT_FILE_ALL_ORDERS_DATA_BY_ORDER_DATE_GENERAL, fromDate, toDate);
         }
 
@@ -380,21 +381,21 @@ namespace FikaAmazonAPI.ReportGeneration
             var dateList = ReportDateRange.GetDateRange(fromDate, toDate, DAY_30);
             foreach (var range in dateList)
             {
-                var path = await GetOrderInvoicingDataAsync(_amazonConnection, range.StartDate, range.EndDate,
+                using var stream = await GetOrderInvoicingDataAsync(_amazonConnection, range.StartDate, range.EndDate,
                     marketplaces);
-                OrderInvoicingReport report = new OrderInvoicingReport(path, _amazonConnection.RefNumber);
+                OrderInvoicingReport report = new OrderInvoicingReport(stream, _amazonConnection.RefNumber);
                 list.AddRange(report.Data);
             }
 
             return list;
         }
 
-        private async Task<string> GetOrderInvoicingDataAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetOrderInvoicingDataAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate, List<MarketPlace> marketplaces = null)
         {
             var options = new AmazonSpApiSDK.Models.Reports.ReportOptions();
             options.Add("ShowSalesChannel", "true");
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_FLAT_FILE_ORDER_REPORT_DATA_INVOICING, fromDate, toDate, options, false, marketplaces);
         }
 
@@ -419,17 +420,17 @@ namespace FikaAmazonAPI.ReportGeneration
             if (totalDays > 90)
                 fromDate = DateTime.UtcNow.AddDays(-90);
 
-            var path = await GetLedgerDetailAsync(_amazonConnection, fromDate, toDate);
-            LedgerDetailReport report = new LedgerDetailReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetLedgerDetailAsync(_amazonConnection, fromDate, toDate);
+            LedgerDetailReport report = new LedgerDetailReport(stream, _amazonConnection.RefNumber);
             list.AddRange(report.Data);
 
             return list;
         }
 
-        private async Task<string> GetLedgerDetailAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetLedgerDetailAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_LEDGER_DETAIL_VIEW_DATA, fromDate, toDate);
         }
 
@@ -442,14 +443,14 @@ namespace FikaAmazonAPI.ReportGeneration
 
         public async Task<List<InventoryPlanningDataRow>> GetInventoryPlanningDataAsync()
         {
-            var path = await GetInventoryPlanningDataAsync(_amazonConnection);
-            InventoryPlanningDataReport report = new InventoryPlanningDataReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetInventoryPlanningDataAsync(_amazonConnection);
+            InventoryPlanningDataReport report = new InventoryPlanningDataReport(stream, _amazonConnection.RefNumber);
             return report.Data;
         }
 
-        private async Task<string> GetInventoryPlanningDataAsync(AmazonConnection amazonConnection)
+        private async Task<MemoryStream> GetInventoryPlanningDataAsync(AmazonConnection amazonConnection)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(ReportTypes
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(ReportTypes
                 .GET_FBA_INVENTORY_PLANNING_DATA);
         }
 
@@ -464,17 +465,17 @@ namespace FikaAmazonAPI.ReportGeneration
         {
             List<FbaEstimateFeeReportRow> list = new List<FbaEstimateFeeReportRow>();
 
-            var path = await GetFbaEstimateFeeDataAsync(_amazonConnection, fromDate, toDate);
-            FbaEstimateFeeReport report = new FbaEstimateFeeReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetFbaEstimateFeeDataAsync(_amazonConnection, fromDate, toDate);
+            FbaEstimateFeeReport report = new FbaEstimateFeeReport(stream, _amazonConnection.RefNumber);
             list.AddRange(report.Data);
 
             return list;
         }
 
-        private async Task<string> GetFbaEstimateFeeDataAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetFbaEstimateFeeDataAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
-            return await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+            return await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                 ReportTypes.GET_FBA_ESTIMATED_FBA_FEES_TXT_DATA, fromDate, toDate);
         }
 
@@ -491,18 +492,18 @@ namespace FikaAmazonAPI.ReportGeneration
         {
             List<ReferralFeeReportRow> list = new List<ReferralFeeReportRow>();
 
-            var path = await GetReferralFeeReportDataAsync(_amazonConnection, fromDate, toDate);
-            ReferralFeeReport report = new ReferralFeeReport(path, _amazonConnection.RefNumber);
+            using var stream = await GetReferralFeeReportDataAsync(_amazonConnection, fromDate, toDate);
+            ReferralFeeReport report = new ReferralFeeReport(stream, _amazonConnection.RefNumber);
             list.AddRange(report.Data);
 
             return list;
         }
 
-        private async Task<string> GetReferralFeeReportDataAsync(AmazonConnection amazonConnection, DateTime fromDate,
+        private async Task<MemoryStream> GetReferralFeeReportDataAsync(AmazonConnection amazonConnection, DateTime fromDate,
             DateTime toDate)
         {
             var reportPath =
-                await amazonConnection.Reports.CreateReportAndDownloadFileAsync(
+                await amazonConnection.Reports.CreateReportAndDownloadFileStreamAsync(
                     ReportTypes.GET_REFERRAL_FEE_PREVIEW_REPORT, fromDate, toDate);
             if (reportPath == null)
             {
@@ -515,7 +516,7 @@ namespace FikaAmazonAPI.ReportGeneration
                 if (getOldReports != null && getOldReports.Count > 0)
                 {
                     var reportId = getOldReports.FirstOrDefault().ReportId;
-                    return await amazonConnection.Reports.GetReportFileByReportIdAsync(reportId, false);
+                    return await amazonConnection.Reports.GetReportFileStreamByReportIdAsync(reportId, false);
                 }
             }
 

--- a/Source/FikaAmazonAPI/ReportGeneration/ReportParser.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportParser.cs
@@ -1,0 +1,60 @@
+using FikaAmazonAPI.ReportGeneration.ReportDataTable;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace FikaAmazonAPI.ReportGeneration
+{
+    internal static class ReportParser
+    {
+        internal static List<T> ParseTableRows<T>(Stream stream, Func<TableRow, string, T> map, string refNumber, Encoding encoding = null)
+        {
+            if (stream == null || stream.Length == 0)
+                return new List<T>();
+
+            stream.Position = 0;
+            var table = Table.ConvertFromCSV(stream, encoding: encoding);
+            var values = new List<T>();
+            if (table != null)
+            {
+                foreach (var row in table.Rows)
+                    values.Add(map(row, refNumber));
+            }
+            return values;
+        }
+
+        internal static List<T> ParseTableRows<T>(Stream stream, Func<TableRow, T> map, Encoding encoding = null)
+        {
+            if (stream == null || stream.Length == 0)
+                return new List<T>();
+
+            stream.Position = 0;
+            var table = Table.ConvertFromCSV(stream, encoding: encoding);
+            var values = new List<T>();
+            if (table != null)
+            {
+                foreach (var row in table.Rows)
+                    values.Add(map(row));
+            }
+            return values;
+        }
+
+        internal static List<T> ParseCsvLines<T>(Stream stream, Func<string, string, T> map, string refNumber, Encoding encoding = null)
+        {
+            if (stream == null || stream.Length == 0)
+                return new List<T>();
+
+            stream.Position = 0;
+            using var reader = new StreamReader(stream, encoding ?? Encoding.UTF8, leaveOpen: true);
+            var lines = new List<string>();
+            while (!reader.EndOfStream)
+                lines.Add(reader.ReadLine());
+
+            return lines.Skip(1)
+                        .Select(l => map(l, refNumber))
+                        .ToList();
+        }
+    }
+}

--- a/Source/FikaAmazonAPI/ReportGeneration/ReportParser.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReportParser.cs
@@ -47,7 +47,8 @@ namespace FikaAmazonAPI.ReportGeneration
                 return new List<T>();
 
             stream.Position = 0;
-            using var reader = new StreamReader(stream, encoding ?? Encoding.UTF8, leaveOpen: true);
+            using var reader = new StreamReader(stream, encoding ?? Encoding.UTF8,
+                detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true);
             var lines = new List<string>();
             while (!reader.EndOfStream)
                 lines.Add(reader.ReadLine());

--- a/Source/FikaAmazonAPI/ReportGeneration/ReturnFBAOrderReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReturnFBAOrderReport.cs
@@ -1,6 +1,8 @@
 ﻿using FikaAmazonAPI.ReportGeneration.ReportDataTable;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -20,6 +22,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(ReturnFBAOrderRow.FromRow(row, refNumber));
             }
             Data = values;
+        }
+
+        public ReturnFBAOrderReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseTableRows(stream, ReturnFBAOrderRow.FromRow, refNumber);
         }
     }
     public class ReturnFBAOrderRow

--- a/Source/FikaAmazonAPI/ReportGeneration/ReturnFBMOrderReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/ReturnFBMOrderReport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -17,6 +18,11 @@ namespace FikaAmazonAPI.ReportGeneration
                                            .Select(v => ReturnFBMOrderRow.FromCsv(v, refNumber))
                                            .ToList();
             Data = values;
+        }
+
+        public ReturnFBMOrderReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseCsvLines(stream, ReturnFBMOrderRow.FromCsv, refNumber);
         }
 
 

--- a/Source/FikaAmazonAPI/ReportGeneration/SettlementOrderReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/SettlementOrderReport.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -20,6 +21,11 @@ namespace FikaAmazonAPI.ReportGeneration
                                            .Select(v => SettlementOrderRow.FromCsv(v, refNumber))
                                            .ToList();
             Data = values;
+        }
+
+        public SettlementOrderReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseCsvLines(stream, SettlementOrderRow.FromCsv, refNumber);
         }
 
 

--- a/Source/FikaAmazonAPI/ReportGeneration/UnsuppressedInventoryDataReport.cs
+++ b/Source/FikaAmazonAPI/ReportGeneration/UnsuppressedInventoryDataReport.cs
@@ -1,5 +1,7 @@
-﻿using FikaAmazonAPI.ReportGeneration.ReportDataTable;
+using FikaAmazonAPI.ReportGeneration.ReportDataTable;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace FikaAmazonAPI.ReportGeneration
 {
@@ -20,6 +22,11 @@ namespace FikaAmazonAPI.ReportGeneration
                 values.Add(UnsuppressedInventoryDataRow.FromRow(row, refNumber));
             }
             Data = values;
+        }
+
+        public UnsuppressedInventoryDataReport(Stream stream, string refNumber)
+        {
+            Data = ReportParser.ParseTableRows(stream, UnsuppressedInventoryDataRow.FromRow, refNumber);
         }
     }
 

--- a/Source/FikaAmazonAPI/Services/ReportService.cs
+++ b/Source/FikaAmazonAPI/Services/ReportService.cs
@@ -303,7 +303,7 @@ namespace FikaAmazonAPI.Services
                     stream = new GZipStream(stream, CompressionMode.Decompress);
 
                 var memoryStream = new MemoryStream();
-                await stream.CopyToAsync(memoryStream, cancellationToken);
+                await stream.CopyToAsync(memoryStream, 81920, cancellationToken);
                 memoryStream.Position = 0;
 
                 return memoryStream;

--- a/Source/FikaAmazonAPI/Services/ReportService.cs
+++ b/Source/FikaAmazonAPI/Services/ReportService.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -194,6 +195,16 @@ namespace FikaAmazonAPI.Services
             return await GetFileAsync(reportDocument, cancellationToken);
         }
 
+        public MemoryStream GetReportFileStream(string reportDocumentId, bool isRestrictedReport = false) =>
+            Task.Run(() => GetReportFileStreamAsync(reportDocumentId, isRestrictedReport)).ConfigureAwait(false).GetAwaiter().GetResult();
+
+        public async Task<MemoryStream> GetReportFileStreamAsync(string reportDocumentId, bool isRestrictedReport = false, CancellationToken cancellationToken = default)
+        {
+            var reportDocument = await GetReportDocumentAsync(reportDocumentId, isRestrictedReport, cancellationToken);
+
+            return await GetFileStreamAsync(reportDocument, cancellationToken);
+        }
+
         private string GetFile(ReportDocument reportDocument) =>
             Task.Run(() => GetFileAsync(reportDocument)).ConfigureAwait(false).GetAwaiter().GetResult();
         private async Task<string> GetFileAsync(ReportDocument reportDocument, CancellationToken cancellationToken = default)
@@ -252,6 +263,53 @@ namespace FikaAmazonAPI.Services
             catch (OperationCanceledException)
             {
                 File.Delete(tempFilePath);
+                throw;
+            }
+        }
+
+        private MemoryStream GetFileStream(ReportDocument reportDocument) =>
+            Task.Run(() => GetFileStreamAsync(reportDocument)).ConfigureAwait(false).GetAwaiter().GetResult();
+
+        private async Task<MemoryStream> GetFileStreamAsync(ReportDocument reportDocument, CancellationToken cancellationToken = default)
+        {
+            bool isCompressionFile = false;
+            bool isEncryptedFile = reportDocument.EncryptionDetails != null;
+
+            if (reportDocument.CompressionAlgorithm is ReportDocument.CompressionAlgorithmEnum.GZIP)
+                isCompressionFile = true;
+
+            var client = new System.Net.WebClient();
+
+            if (isCompressionFile)
+                client.Headers[System.Net.HttpRequestHeader.AcceptEncoding] = "gzip";
+
+            try
+            {
+                Stream stream;
+                if (isEncryptedFile)
+                {
+                    byte[] rawData = client.DownloadData(reportDocument.Url);
+                    byte[] key = Convert.FromBase64String(reportDocument.EncryptionDetails.Key);
+                    byte[] iv = Convert.FromBase64String(reportDocument.EncryptionDetails.InitializationVector);
+                    var reportData = FileTransform.DecryptString(key, iv, rawData);
+                    stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(reportData));
+                }
+                else
+                {
+                    stream = await client.OpenReadTaskAsync(new Uri(reportDocument.Url));
+                }
+
+                if (isCompressionFile)
+                    stream = new GZipStream(stream, CompressionMode.Decompress);
+
+                var memoryStream = new MemoryStream();
+                await stream.CopyToAsync(memoryStream, cancellationToken);
+                memoryStream.Position = 0;
+
+                return memoryStream;
+            }
+            catch (OperationCanceledException)
+            {
                 throw;
             }
         }
@@ -320,6 +378,43 @@ namespace FikaAmazonAPI.Services
 
         }
 
+        public MemoryStream CreateReportAndDownloadFileStream(ReportTypes reportType, DateTime? dataStartTime = null, DateTime? dataEndTime = null, ReportOptions reportOptions = null, bool isRestrictedReport = false, List<MarketPlace> marketplaces = null, int millisecondsDelay = 500) =>
+            Task.Run(() => CreateReportAndDownloadFileStreamAsync(reportType, dataStartTime, dataEndTime, reportOptions, isRestrictedReport, marketplaces, millisecondsDelay)).ConfigureAwait(false).GetAwaiter().GetResult();
+
+        public async Task<MemoryStream> CreateReportAndDownloadFileStreamAsync(ReportTypes reportType, DateTime? dataStartTime = null, DateTime? dataEndTime = null, ReportOptions reportOptions = null, bool isRestrictedReport = false, List<MarketPlace> marketplaces = null, int millisecondsDelay = 500, CancellationToken cancellationToken = default)
+        {
+            if (!isRestrictedReport && Enum.TryParse<RestrictedReportTypes>(reportType.ToString(), out _))
+            {
+                isRestrictedReport = true;
+            }
+
+            var parameters = new ParameterCreateReportSpecification();
+            parameters.reportType = reportType;
+
+            parameters.marketplaceIds = new MarketplaceIds();
+
+            if (marketplaces == null || !marketplaces.Any())
+            {
+                parameters.marketplaceIds.Add(AmazonCredential.MarketPlace.ID);
+            }
+            else
+            {
+                parameters.marketplaceIds.AddRange(marketplaces.Select(x => x.ID).ToList());
+            }
+
+            if (reportOptions != null)
+                parameters.reportOptions = reportOptions;
+
+            if (dataStartTime.HasValue)
+                parameters.dataStartTime = dataStartTime;
+            if (dataEndTime.HasValue)
+                parameters.dataEndTime = dataEndTime;
+
+            var reportId = await CreateReportAsync(parameters, cancellationToken);
+            return await GetReportFileStreamByReportIdAsync(reportId, isRestrictedReport, millisecondsDelay, cancellationToken);
+
+        }
+
         public async Task<string> GetReportFileByReportIdAsync(string reportId, bool isRestrictedReport, int millisecondsDelay = 500, CancellationToken cancellationToken = default)
         {
             var filePath = string.Empty;
@@ -345,6 +440,33 @@ namespace FikaAmazonAPI.Services
                     await Task.Delay(millisecondsDelay, cancellationToken);
             }
             return filePath;
+        }
+
+        public async Task<MemoryStream> GetReportFileStreamByReportIdAsync(string reportId, bool isRestrictedReport, int millisecondsDelay = 500, CancellationToken cancellationToken = default)
+        {
+            MemoryStream stream = null;
+            string ReportDocumentId = string.Empty;
+
+            while (string.IsNullOrEmpty(ReportDocumentId) && !cancellationToken.IsCancellationRequested)
+            {
+                var reportData = await GetReportAsync(reportId, cancellationToken);
+                if (!string.IsNullOrEmpty(reportData.ReportDocumentId))
+                {
+                    stream = await GetReportFileStreamAsync(reportData.ReportDocumentId, isRestrictedReport, cancellationToken);
+                    break;
+                }
+                if (reportData.ProcessingStatus == Report.ProcessingStatusEnum.FATAL)
+                {
+                    throw new Exception("Error with Generate report FATAL");
+                }
+                if (reportData.ProcessingStatus == Report.ProcessingStatusEnum.CANCELLED)
+                {
+                    return null;
+                }
+                else
+                    await Task.Delay(millisecondsDelay, cancellationToken);
+            }
+            return stream;
         }
 
 
@@ -383,6 +505,43 @@ namespace FikaAmazonAPI.Services
             }
 
             return reportsPath;
+        }
+
+        public IList<MemoryStream> DownloadExistingReportAndDownloadFileStream(ReportTypes reportTypes, DateTime? createdSince = null, DateTime? createdUntil = null) =>
+            Task.Run(() => DownloadExistingReportAndDownloadFileStreamAsync(reportTypes, createdSince, createdUntil)).ConfigureAwait(false).GetAwaiter().GetResult();
+
+        public async Task<IList<MemoryStream>> DownloadExistingReportAndDownloadFileStreamAsync(ReportTypes reportTypes, DateTime? createdSince = null, DateTime? createdUntil = null, CancellationToken cancellationToken = default)
+        {
+            var parameters = new ParameterReportList();
+            parameters.reportTypes = new List<ReportTypes>();
+            parameters.reportTypes.Add(reportTypes);
+
+            parameters.marketplaceIds = new MarketplaceIds();
+            parameters.marketplaceIds.Add(AmazonCredential.MarketPlace.ID);
+
+            if (createdSince.HasValue)
+                parameters.createdSince = createdSince;
+            if (createdUntil.HasValue)
+                parameters.createdUntil = createdUntil;
+
+            var reports = await GetReportsAsync(parameters, cancellationToken);
+
+            var reportsStreams = new List<MemoryStream>();
+
+            if (reports != null)
+            {
+                foreach (var reportData in reports)
+                {
+                    if (!string.IsNullOrEmpty(reportData.ReportDocumentId))
+                    {
+                        var stream = await GetReportFileStreamAsync(reportData.ReportDocumentId, cancellationToken: cancellationToken);
+                        reportsStreams.Add(stream);
+
+                    }
+                }
+            }
+
+            return reportsStreams;
         }
     }
 }


### PR DESCRIPTION
## Summary
- centralize CSV and table stream parsing into a new `ReportParser`
- use `ReportParser` across report classes to remove duplicate constructor logic

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686796d8dcbc8322a18b9e6d6b592e47