### PR TITLE
Fixed null exception when SQS has no messages. (Issue #883)

### DIFF
--- a/Source/FikaAmazonAPI/Services/NotificationService.cs
+++ b/Source/FikaAmazonAPI/Services/NotificationService.cs
@@ -136,18 +136,18 @@ namespace FikaAmazonAPI.Services
                     try
                     {
                         var result = await amazonSQSClient.ReceiveMessageAsync(receiveMessageRequest, cancellationToken);
-                        var Messages = result.Messages;
-                        if (Messages != null && Messages.Count > 0)
+                        var Messages = result.Messages ?? new List<Message>();
+                        if (Messages.Count > 0)
                         {
                             foreach (var msg in Messages)
                             {
                                 ProcessAnyOfferChangedMessage(msg, messageReceiver, amazonSQSClient, SQS_URL, isDeleteNotificationAfterRead, cancellationToken).ConfigureAwait(false);
 
                             }
-
-                            if (Messages.Count < 10)
-                                Thread.Sleep(1000 * 5);
                         }
+
+                        if (Messages.Count < 10)
+                            Thread.Sleep(1000 * 5);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
When the SQS has no messages, result.Messages resolves to null.
Added a simple check to ensure messages are present before continuing.
Also moved Thread.Sleep to include the case where no messages are returned. In order to stop the constant calls to SQS.
Resolves https://github.com/abuzuhri/Amazon-SP-API-CSharp/issues/883