### PR TITLE
Fix batch pricing API: flatten queryParams to top-level properties (Amazon API contract change 2026-04-23)

### DIFF
--- a/Source/FikaAmazonAPI/Parameter/ProductPricing/ItemOffersRequest.cs
+++ b/Source/FikaAmazonAPI/Parameter/ProductPricing/ItemOffersRequest.cs
@@ -28,25 +28,17 @@ namespace FikaAmazonAPI.Parameter.ProductPricing
         [JsonProperty("method")]
         public HttpMethodEnum HttpMethod { get; set; }
 
-        //[JsonProperty("headers")]
-        //public Dictionary<string, string> Headers { get; set; }
-
-        [JsonProperty("queryParams")]
+        // Amazon changed their batch API contract: query params must be serialized at the top level, not nested under "queryParams".
+        [JsonIgnore]
         public ParameterGetItemOffers QueryParams { get; set; }
 
-        ///// <summary>
-        ///// A marketplace identifier. Specifies the marketplace for which prices are returned.
-        ///// </summary>
-        //[DataMember(Name = "MarketplaceId")]
-        //public string MarketplaceId { get; set; }
+        [JsonProperty("MarketplaceId")]
+        public string MarketplaceId => QueryParams?.MarketplaceId;
 
-        //[DataMember(Name = "ItemCondition")]
-        //public ItemCondition ItemCondition { get; set; }
+        [JsonProperty("ItemCondition")]
+        public ItemCondition ItemCondition => QueryParams?.ItemCondition ?? default;
 
-        //[DataMember(Name = "CustomerType")]
-        //public CustomerType? CustomerType { get; set; }
-
-        //[JsonIgnore]
-        //public string Asin { get; set; }
+        [JsonProperty("CustomerType")]
+        public CustomerType? CustomerType => QueryParams?.CustomerType;
     }
 }

--- a/Source/FikaAmazonAPI/Parameter/ProductPricing/ListingOffersRequest.cs
+++ b/Source/FikaAmazonAPI/Parameter/ProductPricing/ListingOffersRequest.cs
@@ -28,10 +28,17 @@ namespace FikaAmazonAPI.Parameter.ProductPricing
         [JsonProperty("method")]
         public HttpMethodEnum HttpMethod { get; set; }
 
-        //[JsonProperty("headers")]
-        //public Dictionary<string, string> Headers { get; set; }
-
-        [JsonProperty("queryParams")]
+        // Amazon changed their batch API contract: query params must be serialized at the top level, not nested under "queryParams".
+        [JsonIgnore]
         public ParameterGetListingOffers QueryParams { get; set; }
+
+        [JsonProperty("MarketplaceId")]
+        public string MarketplaceId => QueryParams?.MarketplaceId;
+
+        [JsonProperty("ItemCondition")]
+        public ItemCondition ItemCondition => QueryParams?.ItemCondition ?? default;
+
+        [JsonProperty("CustomerType")]
+        public CustomerType? CustomerType => QueryParams?.CustomerType;
     }
 }


### PR DESCRIPTION
## Problem

Starting **2026-04-23**, all calls to the batch pricing endpoints began failing with HTTP 400:

> Requested MarketplaceId is invalid, unsupported, or does not exist.

The affected endpoints are:
- `POST /batches/products/pricing/v0/itemOffers`
- `POST /batches/products/pricing/v0/listingOffers`

Amazon changed their API contract to require query parameters to be serialized at the **top level** of each individual request object, rather than nested under a `queryParams` key.

### Previously accepted (now broken)
```json
{
  "uri": "/products/pricing/v0/items/B0001/offers",
  "method": "GET",
  "queryParams": {
    "MarketplaceId": "ATVPDKIKX0DER",
    "ItemCondition": "New",
    "CustomerType": "Consumer"
  }
}
```

### Now required
```json
{
  "uri": "/products/pricing/v0/items/B0001/offers",
  "method": "GET",
  "MarketplaceId": "ATVPDKIKX0DER",
  "ItemCondition": "New",
  "CustomerType": "Consumer"
}
```

## Fix

Marked `QueryParams` as `[JsonIgnore]` in both `ItemOffersRequest` and `ListingOffersRequest`, and added `MarketplaceId`, `ItemCondition`, and `CustomerType` as direct `[JsonProperty]` computed properties that delegate to the existing `QueryParams` object.

This is a non-breaking change — the public API surface (`QueryParams` property, all parameter classes) is unchanged. Only the JSON wire format is affected.