### PR TITLE
Align with Amazon SP-API 2025 deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ For more information about keys, check the [Amazon developer documentation](http
 ---
 ## Usage
 
-> ### Please be aware there has been a change to the _Orders.GetOrderAddress()_ method please reference the new sample code for more details.
+> ### Heads-up: Amazon-side changes affecting this library
+>
+> - **Catalog Items API v0 was removed by Amazon on 2025-03-31.** `CatalogItem.ListCatalogItems`, `CatalogItem.ListCatalogCategories`, and `CatalogItem.GetCatalogItemJson` are now marked obsolete because the underlying endpoints no longer exist. Use the 2022-04-01 methods (`SearchCatalogItems202204`, `GetCatalogItem202204`) instead.
+> - **XML feed types (e.g. the legacy inventory feed) were turned off on 2025-07-31.** If you previously submitted inventory updates with `_POST_INVENTORY_AVAILABILITY_DATA_` or similar XML feed types, migrate to `FeedType.JSON_LISTINGS_FEED` with a JSON-Patch payload (see `FeedsSample.cs`).
+> - **Orders API v0 will be removed on 2027-03-27.** All six v0 operations (`getOrders`, `getOrder`, `getOrderBuyerInfo`, `getOrderAddress`, `getOrderItems`, `getOrderItemsBuyerInfo`) will start failing on that date. For new code, prefer `amazonConnection.OrdersV20260101` (Orders API v2026-01-01), which collapses those six operations into `getOrder` and `searchOrders`.
+> - **`Address.Name` (Orders v0) is now optional** as of Amazon's 2025-10 release. The constructor in `AmazonSpApiSDK.Models.Orders.Address` no longer throws when `name` is null — handle null `Name` defensively in your code.
 
 ### Configuration
 You can configure a connection as shown below. See [Here](https://github.com/abuzuhri/Amazon-SP-API-CSharp/blob/main/Source/FikaAmazonAPI.SampleCode/Program.cs) for the relevant code file.

--- a/Source/FikaAmazonAPI.SampleCode/CatalogItemsSample.cs
+++ b/Source/FikaAmazonAPI.SampleCode/CatalogItemsSample.cs
@@ -19,13 +19,14 @@ namespace FikaAmazonAPI.SampleCode
 
         }
 
+        [Obsolete("Catalog Items API v0 was removed by Amazon on 2025-03-31; this call will fail at runtime. The 2022-04-01 version of the API does not expose a categories endpoint.", true)]
         public void ListCatalogCategories()
         {
             var item = amazonConnection.CatalogItem.ListCatalogCategories("B00CZC5F0G");
 
         }
 
-        [Obsolete("This method deprecated in June 2022. Please use SearchCatalogItems202204 instead.", true)]
+        [Obsolete("Catalog Items API v0 was removed by Amazon on 2025-03-31; this call will fail at runtime. Use SearchCatalogItems202204 instead.", true)]
         public void ListCatalogItems()
         {
             var items = amazonConnection.CatalogItem.ListCatalogItems(new Parameter.CatalogItems.ParameterListCatalogItems()

--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/Address.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Orders/Address.cs
@@ -13,7 +13,6 @@ using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.IO;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -60,7 +59,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Orders
         /// <summary>
         /// Initializes a new instance of the <see cref="Address" /> class.
         /// </summary>
-        /// <param name="name">The name. (required).</param>
+        /// <param name="name">The name..</param>
         /// <param name="companyName">The name of the business or organization at this address..</param>
         /// <param name="addressLine1">The street address..</param>
         /// <param name="addressLine2">Additional street address information, if required..</param>
@@ -76,15 +75,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Orders
         /// <param name="addressType">The address type of the shipping address..</param>
         public Address(string name = default(string), string companyName = default(string), string addressLine1 = default(string), string addressLine2 = default(string), string addressLine3 = default(string), string city = default(string), string county = default(string), string district = default(string), string stateOrRegion = default(string), string municipality = default(string), string postalCode = default(string), string countryCode = default(string), string phone = default(string), AddressTypeEnum? addressType = default(AddressTypeEnum?))
         {
-            // to ensure "name" is required (not null)
-            if (name == null)
-            {
-                throw new InvalidDataException("name is a required property for Address and cannot be null");
-            }
-            else
-            {
-                this.Name = name;
-            }
+            this.Name = name;
             this.CompanyName = companyName;
             this.AddressLine1 = addressLine1;
             this.AddressLine2 = addressLine2;

--- a/Source/FikaAmazonAPI/Services/CatalogItemService.cs
+++ b/Source/FikaAmazonAPI/Services/CatalogItemService.cs
@@ -20,12 +20,12 @@ namespace FikaAmazonAPI.Services
 
         }
 
-        [Obsolete("This method deprecated in June 2022. Please use SearchCatalogItems202204 instead.", false)]
+        [Obsolete("Catalog Items API v0 was removed by Amazon on 2025-03-31; this call will fail at runtime. Use SearchCatalogItems202204 instead.", false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IList<Item> ListCatalogItems(ParameterListCatalogItems parameterListCatalogItems) =>
             Task.Run(() => ListCatalogItemsAsync(parameterListCatalogItems)).ConfigureAwait(false).GetAwaiter().GetResult();
 
-        [Obsolete("This method deprecated in June 2022. Please use SearchCatalogItems202204Async instead.", false)]
+        [Obsolete("Catalog Items API v0 was removed by Amazon on 2025-03-31; this call will fail at runtime. Use SearchCatalogItems202204Async instead.", false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public async Task<IList<Item>> ListCatalogItemsAsync(ParameterListCatalogItems parameterListCatalogItems)
         {
@@ -54,9 +54,13 @@ namespace FikaAmazonAPI.Services
 
             return list;
         }
+        [Obsolete("Catalog Items API v0 was removed by Amazon on 2025-03-31; this call will fail at runtime. Use GetCatalogItem202204 instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public String GetCatalogItemJson(string asin) =>
             Task.Run(() => GetCatalogItemAsyncJson(asin)).ConfigureAwait(false).GetAwaiter().GetResult();
 
+        [Obsolete("Catalog Items API v0 was removed by Amazon on 2025-03-31; this call will fail at runtime. Use GetCatalogItem202204Async instead.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public async Task<String> GetCatalogItemAsyncJson(string asin)
         {
 
@@ -99,9 +103,13 @@ namespace FikaAmazonAPI.Services
         }
 
 
+        [Obsolete("Catalog Items API v0 was removed by Amazon on 2025-03-31; this call will fail at runtime. The 2022-04-01 version of the API does not expose a categories endpoint.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public IList<Categories> ListCatalogCategories(string ASIN, string SellerSKU = null, string MarketPlaceID = null) =>
                     Task.Run(() => ListCatalogCategoriesAsync(ASIN, SellerSKU, MarketPlaceID)).ConfigureAwait(false).GetAwaiter().GetResult();
 
+        [Obsolete("Catalog Items API v0 was removed by Amazon on 2025-03-31; this call will fail at runtime. The 2022-04-01 version of the API does not expose a categories endpoint.", false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public async Task<IList<Categories>> ListCatalogCategoriesAsync(string ASIN, string SellerSKU = null, string MarketPlaceID = null, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(ASIN))


### PR DESCRIPTION
- Mark Catalog Items v0 calls (ListCatalogItems, ListCatalogCategories, GetCatalogItemJson) as [Obsolete] with messages noting Amazon removed v0 on 2025-03-31; the underlying URLs return 404. Mirror the obsolete on the matching sample.
- Drop the 'name is required' null-check from Orders v0 Address ctor since Amazon's 2025-10 release made Name optional on getOrderAddress.
- README: replace stale GetOrderAddress notice with a heads-up block covering Catalog v0 removal, XML feeds shutoff (2025-07-31), Orders v0 sunset (2027-03-27) and the OrdersV20260101 path, and Address.Name now optional.