### PR TITLE
Add additive SP-API model fields from 2025-2026 release notes

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/FbaInbound/ItemEligibilityPreview.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/FbaInbound/ItemEligibilityPreview.cs
@@ -284,10 +284,16 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FbaInbound
             FBAINB0104 = 37,
 
             /// <summary>
+            /// Enum FBAINB0465 for value: FBA_INB_0465
+            /// </summary>
+            [EnumMember(Value = "FBA_INB_0465")]
+            FBAINB0465 = 38,
+
+            /// <summary>
             /// Enum UNKNOWNINBERRORCODE for value: UNKNOWN_INB_ERROR_CODE
             /// </summary>
             [EnumMember(Value = "UNKNOWN_INB_ERROR_CODE")]
-            UNKNOWNINBERRORCODE = 38
+            UNKNOWNINBERRORCODE = 39
         }
 
 

--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/FulfillmentInboundv20240320/Address.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/FulfillmentInboundv20240320/Address.cs
@@ -43,6 +43,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
         /// <param name="phoneNumber">The phone number.</param>
         /// <param name="postalCode">The postal code. (required).</param>
         /// <param name="stateOrProvinceCode">The state or province code..</param>
+        /// <param name="districtOrCounty">The district or county.</param>
         public Address(string addressLine1 = default(string),
                        string addressLine2 = default(string),
                        string city = default(string),
@@ -52,7 +53,8 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
                        string name = default(string),
                        string phoneNumber = default(string),
                        string postalCode = default(string),
-                       string stateOrProvinceCode = default(string))
+                       string stateOrProvinceCode = default(string),
+                       string districtOrCounty = default(string))
         {
             // to ensure "addressLine1" is required (not null)
             if (addressLine1 == null)
@@ -104,6 +106,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
             this.Email = email;
             this.PhoneNumber = phoneNumber;
             this.StateOrProvinceCode = stateOrProvinceCode;
+            this.DistrictOrCounty = districtOrCounty;
         }
         
         /// <summary>
@@ -177,6 +180,13 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
         public string StateOrProvinceCode { get; set; }
 
         /// <summary>
+        /// The district or county.
+        /// </summary>
+        /// <value>The district or county.</value>
+        [DataMember(Name="districtOrCounty", EmitDefaultValue=false)]
+        public string DistrictOrCounty { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -194,6 +204,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
             sb.Append("  PhoneNumber: ").Append(PhoneNumber).Append("\n");
             sb.Append("  PostalCode: ").Append(PostalCode).Append("\n");
             sb.Append("  StateOrProvinceCode: ").Append(StateOrProvinceCode).Append("\n");
+            sb.Append("  DistrictOrCounty: ").Append(DistrictOrCounty).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -277,6 +288,11 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
                     this.StateOrProvinceCode == input.StateOrProvinceCode ||
                     (this.StateOrProvinceCode != null &&
                     this.StateOrProvinceCode.Equals(input.StateOrProvinceCode))
+                ) &&
+                (
+                    this.DistrictOrCounty == input.DistrictOrCounty ||
+                    (this.DistrictOrCounty != null &&
+                    this.DistrictOrCounty.Equals(input.DistrictOrCounty))
                 );
         }
 
@@ -309,6 +325,8 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
                     hashCode = hashCode * 59 + this.PostalCode.GetHashCode();
                 if (this.StateOrProvinceCode != null)
                     hashCode = hashCode * 59 + this.StateOrProvinceCode.GetHashCode();
+                if (this.DistrictOrCounty != null)
+                    hashCode = hashCode * 59 + this.DistrictOrCounty.GetHashCode();
                 return hashCode;
             }
         }

--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/FulfillmentInboundv20240320/AddressInput.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/FulfillmentInboundv20240320/AddressInput.cs
@@ -43,6 +43,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
         /// <param name="phoneNumber">The phone number. (required).</param>
         /// <param name="postalCode">The postal code. (required).</param>
         /// <param name="stateOrProvinceCode">The state or province code..</param>
+        /// <param name="districtOrCounty">The district or county.</param>
         public AddressInput(string addressLine1 = default(string),
                             string addressLine2 = default(string),
                             string city = default(string),
@@ -52,7 +53,8 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
                             string name = default(string),
                             string phoneNumber = default(string),
                             string postalCode = default(string),
-                            string stateOrProvinceCode = default(string))
+                            string stateOrProvinceCode = default(string),
+                            string districtOrCounty = default(string))
         {
             // to ensure "addressLine1" is required (not null)
             if (addressLine1 == null)
@@ -112,6 +114,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
             this.CompanyName = companyName;
             this.Email = email;
             this.StateOrProvinceCode = stateOrProvinceCode;
+            this.DistrictOrCounty = districtOrCounty;
         }
         
         /// <summary>
@@ -185,6 +188,13 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
         public string StateOrProvinceCode { get; set; }
 
         /// <summary>
+        /// The district or county.
+        /// </summary>
+        /// <value>The district or county.</value>
+        [DataMember(Name="districtOrCounty", EmitDefaultValue=false)]
+        public string DistrictOrCounty { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -202,6 +212,7 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
             sb.Append("  PhoneNumber: ").Append(PhoneNumber).Append("\n");
             sb.Append("  PostalCode: ").Append(PostalCode).Append("\n");
             sb.Append("  StateOrProvinceCode: ").Append(StateOrProvinceCode).Append("\n");
+            sb.Append("  DistrictOrCounty: ").Append(DistrictOrCounty).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -285,6 +296,11 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
                     this.StateOrProvinceCode == input.StateOrProvinceCode ||
                     (this.StateOrProvinceCode != null &&
                     this.StateOrProvinceCode.Equals(input.StateOrProvinceCode))
+                ) &&
+                (
+                    this.DistrictOrCounty == input.DistrictOrCounty ||
+                    (this.DistrictOrCounty != null &&
+                    this.DistrictOrCounty.Equals(input.DistrictOrCounty))
                 );
         }
 
@@ -317,6 +333,8 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.FulfillmentInboundv20240320
                     hashCode = hashCode * 59 + this.PostalCode.GetHashCode();
                 if (this.StateOrProvinceCode != null)
                     hashCode = hashCode * 59 + this.StateOrProvinceCode.GetHashCode();
+                if (this.DistrictOrCounty != null)
+                    hashCode = hashCode * 59 + this.DistrictOrCounty.GetHashCode();
                 return hashCode;
             }
         }


### PR DESCRIPTION
- FbaInbound IneligibilityReasonListEnum: add FBA_INB_0465 (per Amazon's 2026-04 release note). Bump UNKNOWN_INB_ERROR_CODE to int 39 — safe because the enum is StringEnumConverter-serialized.
- FulfillmentInboundv20240320 Address + AddressInput: add the optional districtOrCounty property (per Amazon's 2025-08 release note for TR marketplace support). Property added at the end of the constructor's optional parameter list to keep positional callers compatible.

DropOffLocation MAIL_ROOM_CLERK / AS_INSTRUCTED is a no-op — this SDK models DropOffLocation as a free-form string, so any value works without code changes. AvailabilityType BLOCKED / DISCOUNTED is already present.