### PR TITLE
feat(financial-events): add ShipmentSettleEventList for DD+7 delivery date policy

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Finances/FinancialEvents.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/Finances/FinancialEvents.cs
@@ -83,6 +83,12 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.Finances
         public ShipmentEventList ShipmentEventList { get; set; }
 
         /// <summary>
+        /// A list of shipment settle events for orders subject to the Delivery Date Policy (DD+7).
+        /// </summary>
+        [DataMember(Name = "ShipmentSettleEventList", EmitDefaultValue = false)]
+        public ShipmentEventList ShipmentSettleEventList { get; set; }
+
+        /// <summary>
         /// A list of refund events.
         /// </summary>
         /// <value>A list of refund events.</value>


### PR DESCRIPTION
## Summary

Amazon returns a `ShipmentSettleEventList` in the v0 Finances API `FinancialEvents` response for orders subject to the Delivery Date Policy (DD+7). This property was missing from the `FinancialEvents` model, causing those settle events to be silently discarded during deserialisation.

## Test plan

- [ ] Build passes with 0 errors (`dotnet build`)
- [ ] Confirm `ShipmentSettleEventList` is populated when deserialising a `FinancialEvents` response containing DD+7 settle events