### PR TITLE
fix(parameter-based): respect [EnumMember] attribute when serialising enum query parameters

### DIFF
--- a/Source/FikaAmazonAPI.SampleCode/FinancialSample.cs
+++ b/Source/FikaAmazonAPI.SampleCode/FinancialSample.cs
@@ -65,7 +65,7 @@ namespace FikaAmazonAPI.SampleCode
                 new Parameter.Finance.ParameterListFinancialTransactions20240619()
                 {
                     postedAfter = DateTime.UtcNow.AddDays(-30),
-                    relatedIdentifierName = "FINANCIAL_EVENT_GROUP_ID",
+                    relatedIdentifierName = RelatedIdentifier.RelatedIdentifierNameEnum.FINANCIALEVENTGROUPID,
                     relatedIdentifierValue = financialEventGroupId,
                 });
         }

--- a/Source/FikaAmazonAPI/Parameter/Finance/ParameterListFinancialTransactions20240619.cs
+++ b/Source/FikaAmazonAPI/Parameter/Finance/ParameterListFinancialTransactions20240619.cs
@@ -19,10 +19,10 @@ namespace FikaAmazonAPI.Parameter.Finance
         /// </summary>
         public string? transactionStatus { get; set; }
         /// <summary>
-        /// Possible values:`FINANCIAL_EVENT_GROUP_ID`: the financial event group ID associated with the transaction.
-        ///*Note: FINANCIAL_EVENT_GROUP_ID is the only `relatedIdentifier` with filtering capabilities at the moment. While other `relatedIdentifier` values will be included in the response when available, they cannot be used for filtering purposes.
+        /// The identifier name to filter by. Only FINANCIAL_EVENT_GROUP_ID has filtering capability at the moment;
+        /// other values appear in response payloads but cannot be used as query filters.
         /// </summary>
-        public string? relatedIdentifierName { get; set; }
+        public RelatedIdentifierNameEnum? relatedIdentifierName { get; set; }
         public string? relatedIdentifierValue { get; set; }
         public string nextToken { get; set; }
         public int? MaxNumberOfPages { get; set; }

--- a/Source/FikaAmazonAPI/Parameter/ParameterBased.cs
+++ b/Source/FikaAmazonAPI/Parameter/ParameterBased.cs
@@ -57,11 +57,22 @@ namespace FikaAmazonAPI.Search
                     }
                     else if (p.PropertyType.IsEnum || IsNullableEnum(p.PropertyType))
                     {
-                        output = value.ToString();
+                        var enumSettings = new JsonSerializerSettings
+                        {
+                            Converters = new List<JsonConverter> { new StringEnumConverter() }
+                        };
+                        output = JsonConvert.SerializeObject(value, enumSettings).Trim('"');
                     }
                     else if (IsEnumerableOfEnum(p.PropertyType) || IsEnumerable(p.PropertyType))
                     {
-                        var data = ((ICollection)value).Cast<object>().Select(a => a.ToString());
+                        var enumSettings = new JsonSerializerSettings
+                        {
+                            Converters = new List<JsonConverter> { new StringEnumConverter() }
+                        };
+                        var data = ((ICollection)value).Cast<object>()
+                            .Select(a => a.GetType().IsEnum
+                                ? JsonConvert.SerializeObject(a, enumSettings).Trim('"')
+                                : a.ToString());
                         if (data.Count() > 0)
                         {
                             var result = data.ToArray();


### PR DESCRIPTION
## Summary

- `ParameterBased.getParameters()` was calling `.ToString()` on enum values, producing the C# identifier name (e.g. `FINANCIALEVENTGROUPID`) instead of the wire format declared via `[EnumMember(Value = "...")]` (e.g. `FINANCIAL_EVENT_GROUP_ID`). Amazon APIs silently reject the malformed values, making every enum-typed query parameter effectively broken when the C# member name differs from the API wire value.
- Fixed by using `StringEnumConverter` (Newtonsoft.Json) in both the scalar enum branch and the `IEnumerable<TEnum>` branch, consistent with the fallback path that was already doing this correctly for other types.
- `relatedIdentifierName` on `ParameterListFinancialTransactions20240619` is now typed as `RelatedIdentifierNameEnum?` instead of `string?`, taking advantage of the fixed serialisation.

## Root cause

```csharp
// Before - ignores [EnumMember(Value = "FINANCIAL_EVENT_GROUP_ID")]
else if (p.PropertyType.IsEnum || IsNullableEnum(p.PropertyType))
{
    output = value.ToString();  // produces "FINANCIALEVENTGROUPID"
}

// After - respects [EnumMember] attribute
else if (p.PropertyType.IsEnum || IsNullableEnum(p.PropertyType))
{
    var enumSettings = new JsonSerializerSettings
    {
        Converters = new List<JsonConverter> { new StringEnumConverter() }
    };
    output = JsonConvert.SerializeObject(value, enumSettings).Trim('"');
}
```

## Test plan

- [ ] Build passes with 0 errors (`dotnet build`)
- [ ] Verify that `ParameterListFinancialTransactions20240619` with `relatedIdentifierName = RelatedIdentifierNameEnum.FINANCIALEVENTGROUPID` produces `relatedIdentifierName=FINANCIAL_EVENT_GROUP_ID` in the query string
- [ ] Check other enum-typed parameters in other `ParameterBased` subclasses produce their expected wire values