### PR TITLE
Added "DISTRIBUTOR_PRICE" to PriceDesignationEnum

### DIFF
--- a/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/OrdersV20260101/PriceDesignationEnum.cs
+++ b/Source/FikaAmazonAPI/AmazonSpApiSDK/Models/OrdersV20260101/PriceDesignationEnum.cs
@@ -22,7 +22,13 @@ namespace FikaAmazonAPI.AmazonSpApiSDK.Models.OrdersV20260101
         /// Enum value for type QUANTITY_PRICE
         /// </summary>
         [EnumMember(Value = "QUANTITY_PRICE")]
-        QUANTITY_PRICE = 2
+        QUANTITY_PRICE = 2,
+
+        /// <summary>
+        /// Enum value for type DISTRIBUTOR_PRICE
+        /// </summary>
+        [EnumMember(Value = "DISTRIBUTOR_PRICE")]
+        DISTRIBUTOR_PRICE = 3,
     }
 
 }


### PR DESCRIPTION
Added DISTRIBUTOR_PRICE to PriceDesignationEnum to prevent deserialization errors caused by undocumented enum values returned by the SP‑API. Reference: issue https://github.com/abuzuhri/Amazon-SP-API-CSharp/issues/947#issue-4747611410.